### PR TITLE
Logger missing items

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *~
 *__pycache__*
 .ropeproject/
+katal/.katal

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 *~
 *__pycache__*
 .ropeproject/
-katal/.katal

--- a/katal/katal.py
+++ b/katal/katal.py
@@ -2332,9 +2332,9 @@ def main_warmup(timestamp_start):
                                      CST__KATALSYS_SUBDIR, CST__TASKS_SUBSUBDIR), "tasks subdir"),
                        (os.path.join(normpath(ARGS.targetpath),
                                      CST__KATALSYS_SUBDIR, CST__LOG_SUBSUBDIR), "log subdir"),):
-        LOGGER.info("  = let's use \"%s\" as %s", path, info)
+        LOGGER.debug("  = let's use \"%s\" as %s", path, info)
 
-    LOGGER.info("  = source directory : \"%s\" (path : \"%s\")",
+    LOGGER.debug("  = source directory : \"%s\" (path : \"%s\")",
                 source_path, normpath(source_path))
 
     #...........................................................................
@@ -3355,18 +3355,18 @@ def welcome(timestamp_start):
     LOGGER.info("="*len(strmsg), color="white")
 
     # command line arguments :
-    LOGGER.info("  = command line arguments : %s", sys.argv)
+    LOGGER.debug("  = command line arguments : %s", sys.argv)
 
     # if the target file doesn't exist, it will be created later by main_warmup() :
     if ARGS.new is None and ARGS.downloaddefaultcfg is None:
-        LOGGER.info("  = target directory given as parameter : \"%s\" "
+        LOGGER.debug("  = target directory given as parameter : \"%s\" "
             "(path : \"%s\")", ARGS.targetpath, normpath(ARGS.targetpath))
 
         if ARGS.configfile is not None:
             LOGGER.info("  = expected config file : \"%s\" "
                 "(path : \"%s\")", ARGS.configfile, normpath(ARGS.configfile))
         else:
-            LOGGER.info("  * no config file specified on the command line : "
+            LOGGER.debug("  * no config file specified on the command line : "
                 "let's search a config file...")
 
     if ARGS.off:
@@ -3378,37 +3378,6 @@ def welcome(timestamp_start):
                     color="cyan")
         LOGGER.info("  =                log file.                                              =",
                     color="cyan")
-
-#///////////////////////////////////////////////////////////////////////////////
-def welcome_in_logfile(timestamp_start):
-    """
-        welcome_in_logfile()
-        ________________________________________________________________________
-
-        The function writes in the log file a welcome message with some very
-        broad informations about the program.
-
-        This function has to be called after the opening of the log file.
-        This function doesn't write anything on the console.
-
-        See welcome() function for more informations since welcome() and
-        welcome_in_logfile() do the same job, the first on console, the
-        second in the log file.
-        ________________________________________________________________________
-
-        PARAMETER :
-                o  timestamp_start : a datetime.datetime object
-
-        no RETURNED VALUE
-    """
-    FILE_LOGGER.info("=== %s v.%s " "(launched at %s) ===",
-                     __projectname__, __version__, timestamp_start.strftime("%Y-%m-%d %H:%M:%S"))
-
-    FILE_LOGGER.info("  = command line arguments : %s", sys.argv)
-
-    FILE_LOGGER.info("  = target directory given as parameter : \"%s\" "
-        "(path : \"%s\")", ARGS.targetpath,
-                                  normpath(ARGS.targetpath))
 
 #///////////////////////////////////////////////////////////////////////////////
 def where_is_the_configfile():

--- a/katal/katal.py
+++ b/katal/katal.py
@@ -193,10 +193,6 @@ CST__KATALSYS_SUBDIR = ".katal"
 
 CST__LOG_SUBSUBDIR = "logs"
 
-CST__LOGFILE_DTIMEFORMATSTR = "%Y_%m_%d__%H%M%S__%f"  # constant of the time format added to old
-                                                      # logfiles' filename .
-                                                      # see the backup_logfile() function .
-
 # suffix, multiple :
 # about the multiples of bytes, see e.g. https://en.wikipedia.org/wiki/Megabyte
 CST__MULTIPLES = (("kB", 1000),
@@ -1269,27 +1265,6 @@ def add_keywords_in_targetstr(srcstring,
     return res
 
 #///////////////////////////////////////////////////////////////////////////////
-def backup_logfile(_logfile_fullname):
-    """
-        backup_logfile()
-        ________________________________________________________________________
-
-        copy a logfile named _logfile_fullname into a backuped file.
-
-          o  The backuped file is stored in the CST__LOG_SUBSUBDIR directory.
-          o  The name of the backuped file is automatically created from a call to
-             datetime.now() . See the CST__LOGFILE_DTIMEFORMATSTR constant.
-        ________________________________________________________________________
-
-        NO PARAMETER, no RETURNED VALUE
-    """
-    logfile_backup = os.path.join(CST__KATALSYS_SUBDIR, CST__LOG_SUBSUBDIR,
-                                  CFG_PARAMETERS["log file"]["name"] + \
-                                  datetime.strftime(datetime.now(),
-                                                    CST__LOGFILE_DTIMEFORMATSTR))
-    shutil.copyfile(_logfile_fullname, logfile_backup)
-
-#///////////////////////////////////////////////////////////////////////////////
 def check_args():
     """
         check_args()
@@ -2045,7 +2020,7 @@ def is_ntfs_prefix_mandatory(path):
     return res
 
 #///////////////////////////////////////////////////////////////////////////////
-def main():
+def main(args=None):
     """
         main()
         ________________________________________________________________________
@@ -2053,7 +2028,13 @@ def main():
         Main entry point.
         ________________________________________________________________________
 
-        no PARAMETER, no RETURNED VALUE
+        PARAMETER:
+            o list(args) (Optionnal, default=None): the list of arguments to
+              parse from the command line. If None, the arguments are taken from
+              sys.argv.
+              Mainly for tests
+
+        no RETURNED VALUE
 
         This function should NOT have arguments : otherwise, the entrypoint
         defined in setup.py would not be valid.
@@ -2067,7 +2048,7 @@ def main():
     timestamp_start = datetime.now()
 
     try:
-        ARGS = read_command_line_arguments()
+        ARGS = read_command_line_arguments(args)
         check_args()
 
         main_warmup(timestamp_start)
@@ -2418,7 +2399,7 @@ def normpath(path):
     return res
 
 #///////////////////////////////////////////////////////////////////////////////
-def read_command_line_arguments():
+def read_command_line_arguments(args=None):
     """
         read_command_line_arguments()
         ________________________________________________________________________
@@ -2426,7 +2407,9 @@ def read_command_line_arguments():
         Read the command line arguments.
         ________________________________________________________________________
 
-        no PARAMETER
+        PARAMETER
+                args (Optional): a list of command line arguments to test. If
+                None, use sys.argv. Mainly for tests.
 
         RETURNED VALUE
                 return the argparse object.
@@ -2599,7 +2582,7 @@ def read_command_line_arguments():
                              "given as a parameter is in the target directory "
                              "notwithstanding its name.")
 
-    return parser.parse_args()
+    return parser.parse_args(args)
 
 #///////////////////////////////////////////////////////////////////////////////
 def possible_paths_to_cfg():

--- a/tests/test_pytest.py
+++ b/tests/test_pytest.py
@@ -1,0 +1,57 @@
+################################################################################
+#    Katal Copyright (C) 2012 Suizokukan
+#    Contact: suizokukan _A.T._ orange dot fr
+#
+#    This file is part of Katal.
+#    Katal is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    Katal is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with Katal.  If not, see <http://www.gnu.org/licenses/>.
+################################################################################
+"""
+       Katal by suizokukan (suizokukan AT orange DOT fr)
+
+       tests.py
+"""
+# Pylint : disabling the "Class 'ARGS' has no 'configfile' member" error
+#          since there IS a 'configfile' member for the ARGS class.
+# pylint: disable=E1101
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from katal import katal
+
+@pytest.fixture(autouse=True)
+def tmp_target_dir(tmpdir):
+    katal.ARGS = MagicMock()
+    katal.ARGS.targetpath = tmpdir
+    return tmpdir
+
+
+def test_initialization(tmp_target_dir):
+    args = '-cfg tests/cfgfile1.ini'.split()
+
+    try:
+        katal.main(args)
+    except SystemExit as system_exit:
+        assert not system_exit.code
+
+
+    path = tmp_target_dir.join(katal.CST__KATALSYS_SUBDIR)
+    for p in ['', katal.CST__LOG_SUBSUBDIR, katal.CST__TRASH_SUBSUBDIR,
+              katal.CST__TASKS_SUBSUBDIR]:
+
+        assert path.join(p).ensure(dir=True)
+
+    assert path.join(katal.get_logfile_fullname()).ensure()
+


### PR DESCRIPTION
Sorry, I have still forgotten some points.

First, I fixed a bug I introduced myself : I forgot to put the subdir creation before definition of loggers, which raise an exception when .katal/logs do not already exist.
To no repeat this I created a test. It uses py.test, which is more practical than unittest. I thought that since because tests are matter of coders, it does not matter if I add a dependancie.
And I deleted some functions no longer used.

Sorry to have forgotten to do this before.
