### PR TITLE
Config

### DIFF
--- a/katal/katal.ini
+++ b/katal/katal.ini
@@ -29,6 +29,9 @@ path : .
 #   eval : not(filter1 | filter2)
 eval : filter1
 
+# Force a bit-to-bit comparision between files whose hashid-s is equal.
+strict comparison : False
+
 [source.filter1]
 # You may use the following filters : 'name', 'iname', 'date' and 'size'
 #

--- a/katal/katal.ini
+++ b/katal/katal.ini
@@ -84,51 +84,50 @@ mode : copy
 
 # the new name for the target files is created using some keywords, see below.
 #
-# o  if mode=nocopy, this paramater will automatically be ignored and replaced by %%i
-# o  beware, due to limitations of the .ini format, use '%%', NOT '%' alone !
-# o  keywords with a reduplicated letter (%%pp, %%ff, ...) are builded against
+# o  if mode=nocopy, this paramater will automatically be ignored and replaced by %i
+# o  keywords with a reduplicated letter (%pp, %ff, ...) are builded against
 #    a set of illegal characters, each illegal character being replaced by "_".
 #    See the remove_illegal_characters() function for a list of these illegal
 #    characters .
 # o  if you want to display files (with a file manager) sorted by date, you may
-#    want to start their name with %%t (not with %%ht, this value
+#    want to start their name with %t (not with %ht, this value
 #    being problematic since Windows10 can't sort correctly files
 #    whose name mixes digits and alphanumerics characters)
 #
 #
-#   %%h  : hashid (e.g. GwM5NKzoZ76oPAbWwX7od0pI66xZrOHI7TWIggx+xFk=)
+#   %h  : hashid (e.g. GwM5NKzoZ76oPAbWwX7od0pI66xZrOHI7TWIggx+xFk=)
 #
-#   %%f  : source name (with the path), without the extension
+#   %f  : source name (with the path), without the extension
 #
-#   %%ff : source name (with the path), without the extension
+#   %ff : source name (with the path), without the extension
 #          [see below, no forbidden characters]
 #
-#   %%p  : source path
+#   %p  : source path
 #
-#   %%pp : source path
+#   %pp : source path
 #          [see below, no forbidden characters]
 #
-#   %%e  : source extension, without the dot character (e.g. jpg / no dot character !)
+#   %e  : source extension, without the dot character (e.g. jpg / no dot character !)
 #
-#   %%ee : source extension, without the dot character (e.g. jpg / no dot character !)
+#   %ee : source extension, without the dot character (e.g. jpg / no dot character !)
 #          [see below, no forbidden characters]
 #
-#   %%s  : size (e.g. 123)
+#   %s  : size (e.g. 123)
 #
-#   %%dd : date (e.g. 2015_09_25_06_50)
+#   %dd : date (e.g. 2015_09_25_06_50)
 #          [see below, no forbidden characters]
 #
-#   %%i  : database index (e.g. 123)
+#   %i  : database index (e.g. 123)
 #
-#   %%t  : timestamp of the file (integer, e.g. 1445584562)
+#   %t  : timestamp of the file (integer, e.g. 1445584562)
 #
-#   %%ht : timestamp of the file (hexadecimal, e.g. 5629DED0)
-name of the target files : %%dd__%%i.%%e
+#   %ht : timestamp of the file (hexadecimal, e.g. 5629DED0)
+name of the target files : %dd__%i.%e
 
 # fill this line to add tags to each source file; use the same keywords as for
 # "name of the target files"; let the string empty if there's no tags to be added.
 #
-# e.g. : "sunshine;trees;extension=%%e"
+# e.g. : "sunshine;trees;extension=%e"
 tags : 
 
 #...............................................................................

--- a/katal/katal.py
+++ b/katal/katal.py
@@ -319,7 +319,7 @@ class ColorFormatter(logging.Formatter):
 
 class Config(configparser.ConfigParser):
     def __init__(self):
-        super().__init__(interpolation=configparser.ExtendedInterpolation())
+        super().__init__(interpolation=None)
 
     def read_config(self):
         self.read_command_line_arguments()

--- a/katal/katal.py
+++ b/katal/katal.py
@@ -318,9 +318,23 @@ class Config(configparser.ConfigParser):
         super().__init__(interpolation=None)
 
     def read_config(self, args=None, cfg_file=None):
+        """
+            self.check_args(args=None, cfg_file=None)
+            ________________________________________________________________________
+
+            Read all the configuration, from the the default configuration, from all
+            posible configuration files, and from the command line.
+            ________________________________________________________________________
+
+            PARAMETERS
+                args (list, optional): list of optional args, to parse as command
+                    line arguments instead of sys.argv
+                cdg_file (str, optional): name of an optional config_file to read
+            no RETURNED VALUE
+        """
         self.read_command_line_arguments(args)
 
-        # TODO: download configfile
+        # TODO: download configfile here and use it
         self.read_dict(self.default_config())    # Initialize the defaults value
         self.read_all_config_files(cfg_file)
         self.read_dict(self.arguments_to_dict()) # Modifications from command line
@@ -328,20 +342,32 @@ class Config(configparser.ConfigParser):
         self.read_parameters_from_cfgfile()
 
     def arguments_to_dict(self):
+        """
+            self.arguments_to_dict()
+            ________________________________________________________________________
+
+            Return a dict from the command line arguments
+            ________________________________________________________________________
+
+            no PARAMETERS
+
+            RETURNED VALUE
+                A dict ready to be passed to self.read_dict
+        """
         return_dict = {'display': {},
                        'source': {},
-                       }
+                      }
         if self.verbosity is not None:
             return_dict['display']['verbosity'] = self.verbosity
 
         if self.strictcmp:
-            return_dict['source']['strict comparison'] =  self.strictcmp
+            return_dict['source']['strict comparison'] = self.strictcmp
 
         return return_dict
 
     def check_args(self, parser):
         """
-            check_args(self, parser)
+            self.check_args(parser)
             ________________________________________________________________________
 
             check the arguments of the command line. Raise a parser error if
@@ -375,7 +401,20 @@ class Config(configparser.ConfigParser):
             parser.error("--copyto can only be used in combination with --findtag .")
 
 #///////////////////////////////////////////////////////////////////////////////
-    def default_config(self):
+    @staticmethod
+    def default_config():
+        """
+            self.default_config()
+            ________________________________________________________________________
+
+            Return the default values for the config.
+            ________________________________________________________________________
+
+            no PARAMETER
+
+            RETURNED VALUE
+                A dict ready to be passed to self.read_dict
+        """
         return {
         'source': {
             'path': '.',
@@ -406,7 +445,22 @@ class Config(configparser.ConfigParser):
     }
 
     def read_all_config_files(self, cfg_file=None):
-        config_files = self.possible_paths_to_cfg(cfg_file)
+        """
+        self.read_all_config_files(cfg_file=None)
+        ________________________________________________________________________
+
+        Update self from all possible config files, from cfg_file if provided and
+        from config file given as a command line argument
+        ________________________________________________________________________
+        PARAMETERS
+            cdg_file (str, optional): name of an optional config_file to read
+
+        no RETURNED VALUE
+        """
+        config_files = self.possible_paths_to_cfg()
+
+        if cfg_file:
+            config_files.append(cfg_file)
 
         self.cfg_files = self.read(config_files)
 
@@ -417,7 +471,7 @@ class Config(configparser.ConfigParser):
                     self.cfg_files.append(self.configfile)
             except FileNotFoundError:
                 print('  ! The config file "%s" (path : "%s") '
-                    " doesn't exist. " % self.configfile, normpath(self.configfile))
+                      "doesn't exist. " % self.configfile, normpath(self.configfile))
                 raise ConfigError
 
         if not self.cfg_files:
@@ -446,10 +500,10 @@ class Config(configparser.ConfigParser):
                                 epilog="{0} v. {1} ({2}), "
                                         "a project by {3} "
                                         "({4})".format(__projectname__,
-                                                        __version__,
-                                                        __license__,
-                                                        __author__,
-                                                        __email__),
+                                                       __version__,
+                                                       __license__,
+                                                       __author__,
+                                                       __email__),
                                 formatter_class=argparse.ArgumentDefaultsHelpFormatter)
 
         exclusive_group = parser.add_mutually_exclusive_group()
@@ -457,16 +511,16 @@ class Config(configparser.ConfigParser):
         exclusive_group.add_argument('--add',
                             action="store_true",
                             help="# Select files according to what is described "
-                                "in the configuration file "
-                                "then add them to the target directory. "
-                                "This option can't be used with the --select one."
-                                "If you want more informations about the process, please "
-                                "use this option in combination with --infos .")
+                                 "in the configuration file "
+                                 "then add them to the target directory. "
+                                 "This option can't be used with the --select one."
+                                 "If you want more informations about the process, please "
+                                 "use this option in combination with --infos .")
 
         parser.add_argument('--addtag',
                             type=str,
                             help="# Add a tag to some file(s) in combination "
-                                "with the --to option. ")
+                                 "with the --to option. ")
 
         parser.add_argument('-cfg', '--configfile',
                             type=str,
@@ -479,26 +533,26 @@ class Config(configparser.ConfigParser):
         parser.add_argument('--copyto',
                             type=str,
                             help="# To be used with the --findtag parameter. Copy the found files "
-                                "into an export directory.")
+                                 "into an export directory.")
 
         parser.add_argument('-dlcfg', '--downloaddefaultcfg',
                             choices=("local", "home",),
                             help="# Download the default config file and overwrite the file having "
-                                "the same name. This is done before the script reads the parameters "
-                                "in the config file. Use 'local' to download in the current "
-                                "directory, 'home' to download in the user's HOME directory.")
+                                 "the same name. This is done before the script reads the parameters "
+                                 "in the config file. Use 'local' to download in the current "
+                                 "directory, 'home' to download in the user's HOME directory.")
 
         parser.add_argument('--findtag',
                             type=str,
                             help="# Find the files in the target directory with the given tag. "
-                                "The tag is a simple string, not a regex.")
+                                 "The tag is a simple string, not a regex.")
 
         parser.add_argument('--infos',
                             action="store_true",
                             help="# Display informations about the source directory "
-                                "given in the configuration file. Help the --select/--add "
-                                "options to display more informations about the process : in "
-                                "this case, the --infos will be executed before --select/--add")
+                                 "given in the configuration file. Help the --select/--add "
+                                 "options to display more informations about the process : in "
+                                 "this case, the --infos will be executed before --select/--add")
 
         parser.add_argument('-n', '--new',
                             type=str,
@@ -507,18 +561,18 @@ class Config(configparser.ConfigParser):
         parser.add_argument('--off',
                             action="store_true",
                             help="# Don't write anything into the target directory or into "
-                                "the database, except into the current log file. "
-                                "Use this option to simulate an operation : you get the messages "
-                                "but no file is modified on disk, no directory is created.")
+                                 "the database, except into the current log file. "
+                                 "Use this option to simulate an operation : you get the messages "
+                                 "but no file is modified on disk, no directory is created.")
 
         parser.add_argument('--rebase',
                             type=str,
                             help="# Copy the current target directory into a new one : you "
-                                "rename the files in the target directory and in the database. "
-                                "First, use the --new option to create a new target directory, "
-                                "modify the .ini file of the new target directory "
-                                "(modify [target]name of the target files), "
-                                "then use --rebase with the name of the new target directory")
+                                 "rename the files in the target directory and in the database. "
+                                 "First, use the --new option to create a new target directory, "
+                                 "modify the .ini file of the new target directory "
+                                 "(modify [target]name of the target files), "
+                                 "then use --rebase with the name of the new target directory")
 
         parser.add_argument('--reset',
                             action="store_true",
@@ -531,25 +585,25 @@ class Config(configparser.ConfigParser):
         parser.add_argument('--rmtags',
                             action="store_true",
                             help="# Remove all the tags of some file(s) in combination "
-                                "with the --to option. ")
+                                 "with the --to option. ")
 
         exclusive_group.add_argument('-s', '--select',
                             action="store_true",
                             help="# Select files according to what is described "
-                                "in the configuration file "
-                                "without adding them to the target directory. "
-                                "This option can't be used with the --add one."
-                                "If you want more informations about the process, please "
-                                "use this option in combination with --infos .")
+                                 "in the configuration file "
+                                 "without adding them to the target directory. "
+                                 "This option can't be used with the --add one."
+                                 "If you want more informations about the process, please "
+                                 "use this option in combination with --infos .")
 
         parser.add_argument('--settagsstr',
                             type=str,
                             help="# Give the tag to some file(s) in combination "
-                                "with the --to option. "
-                                "Overwrite the ancient tag string. "
-                                "If you want to empty the tags' string, please use a space, "
-                                "not an empty string : otherwise the parameter given "
-                                "to the script wouldn't be taken in account by the shell")
+                                 "with the --to option. "
+                                 "Overwrite the ancient tag string. "
+                                 "If you want to empty the tags' string, please use a space, "
+                                 "not an empty string : otherwise the parameter given "
+                                 "to the script wouldn't be taken in account by the shell")
 
         parser.add_argument('-si', '--sourceinfos',
                             action="store_true",
@@ -558,14 +612,14 @@ class Config(configparser.ConfigParser):
         parser.add_argument('--strictcmp',
                             action="store_true",
                             help="# To be used with --add or --select. Force a bit-to-bit comparision"
-                                "between files whose hashid-s is equal.")
+                                 "between files whose hashid-s is equal.")
 
         parser.add_argument('--targetpath',
                             type=str,
                             default=".",
                             help="# Target path, usually '.' . If you set path to . (=dot character)"
-                                ", it means that the source path is the current directory"
-                                " (=the directory where the script katal.py has been launched)")
+                                 ", it means that the source path is the current directory"
+                                 " (=the directory where the script katal.py has been launched)")
 
         parser.add_argument('-ti', '--targetinfos',
                             action="store_true",
@@ -574,9 +628,9 @@ class Config(configparser.ConfigParser):
         parser.add_argument('-tk', '--targetkill',
                             type=str,
                             help="# Kill (=move to the trash directory) one file from "
-                                "the target directory."
-                                "DO NOT GIVE A PATH, just the file's name, "
-                                "without the path to the target directory")
+                                 "the target directory."
+                                 "DO NOT GIVE A PATH, just the file's name, "
+                                 "without the path to the target directory")
 
         parser.add_argument('--to',
                             type=str,
@@ -587,18 +641,18 @@ class Config(configparser.ConfigParser):
         parser.add_argument('--usentfsprefix',
                             action="store_true",
                             help="# Force the script to prefix filenames by a special string "
-                                "required by the NTFS for long filenames, namely \\\\?\\")
+                                 "required by the NTFS for long filenames, namely \\\\?\\")
 
         parser.add_argument('--verbosity',
                             choices=("none", "normal", "high"),
                             default='normal',
                             help="# Console verbosity : "
-                                "'none'=no output to the console, no question asked on the console; "
-                                "'normal'=messages to the console "
-                                "and questions asked on the console; "
-                                "'high'=display discarded files. A question may be asked only by "
-                                "using the following arguments : "
-                                "--new, --rebase, --reset and --select")
+                                 "'none'=no output to the console, no question asked on the console; "
+                                 "'normal'=messages to the console "
+                                 "and questions asked on the console; "
+                                 "'high'=display discarded files. A question may be asked only by "
+                                 "using the following arguments : "
+                                 "--new, --rebase, --reset and --select")
 
         parser.add_argument('--version',
                             action='version',
@@ -608,8 +662,8 @@ class Config(configparser.ConfigParser):
         parser.add_argument('--whatabout',
                             type=str,
                             help="# Say if the file[the files in a directory] already in the "
-                                "given as a parameter is in the target directory "
-                                "notwithstanding its name.")
+                                 "given as a parameter is in the target directory "
+                                 "notwithstanding its name.")
 
         parser.parse_args(args=args, namespace=self)
 
@@ -618,9 +672,9 @@ class Config(configparser.ConfigParser):
         return self
 
     #///////////////////////////////////////////////////////////////////////////////
-    def possible_paths_to_cfg(self, cfg_file=None):
+    def possible_paths_to_cfg(self):
         """
-            possible_paths_to_cfg()
+            selfpossible_paths_to_cfg()
             ________________________________________________________________________
 
             return a list of the (str)paths to the config file, without the name
@@ -653,9 +707,6 @@ class Config(configparser.ConfigParser):
 
         cfg_localisation = [os.path.join(cfg_path, CST__DEFAULT_CONFIGFILE_NAME)
                             for cfg_path in res]
-
-        if cfg_file:
-            cfg_localisation.append(cfg_file)
 
         return cfg_localisation
 
@@ -700,7 +751,7 @@ class Config(configparser.ConfigParser):
             print("  ! An error occured while reading config files.")
             print('  ! Your configuration file lacks a specific value : "%s".' % exception)
             print("  ... you should download a new default config file : "
-                        "see -dlcfg/--downloaddefaultcfg option")
+                  "see -dlcfg/--downloaddefaultcfg option")
             raise ConfigError
         except configparser.Error as exception:
             print("  ! An error occured while reading the config files.")
@@ -817,7 +868,7 @@ class Filter:
                             '%Y-%m-%d',         # '2015-09-17
                             '%Y-%m',            # '2015-09'
                             '%Y',               # '2015'
-                            ):
+                           ):
 
             try:
                 date = datetime.strptime(filter_date, time_format)
@@ -924,7 +975,7 @@ class Filter:
         else:
             if not filter_size[-1].isdigit():
                 raise KatalError("Can't analyse {0} in the filter. "
-                                "Available multiples are : {1}".format(filter_size,
+                                 "Available multiples are : {1}".format(filter_size,
                                                                         CST__MULTIPLES))
         try:
             match_size = float(filter_size) * multiple
@@ -1032,7 +1083,7 @@ class Filter:
                                  ' config key')
 
             res = res.replace("%i",
-                            remove_illegal_characters(str(database_index)))
+                              remove_illegal_characters(str(database_index)))
 
             return res not in list_names
 
@@ -3560,7 +3611,7 @@ def thefilehastobeadded__db(filename, _size):
                 either (False, None, None)
                 either (True, partial hashid, hashid)
     """
-    # (1) hont(datetime.strptime(date, CST__DTIME_FORMAT))w many file(s) in the database have a size equal to _size ?
+    # (1) how many file(s) in the database have a size equal to _size ?
     # a list of hashid(s) :
     res = [hashid for hashid in TARGET_DB if TARGET_DB[hashid][1] == _size]
 

--- a/katal/katal.py
+++ b/katal/katal.py
@@ -317,18 +317,20 @@ class Config(configparser.ConfigParser):
     def __init__(self):
         super().__init__(interpolation=None)
 
-    def read_config(self, args=None):
+    def read_config(self, args=None, cfg_file=None):
         self.read_command_line_arguments(args)
 
         # TODO: download configfile
         self.read_dict(self.default_config())    # Initialize the defaults value
-        self.read_all_config_files()
+        self.read_all_config_files(cfg_file)
         self.read_dict(self.arguments_to_dict()) # Modifications from command line
 
         self.read_parameters_from_cfgfile()
 
     def arguments_to_dict(self):
-        return_dict = {}
+        return_dict = {'display': {},
+                       'source': {},
+                       }
         if self.verbosity is not None:
             return_dict['display']['verbosity'] = self.verbosity
 
@@ -403,8 +405,8 @@ class Config(configparser.ConfigParser):
         'tags': {}
     }
 
-    def read_all_config_files(self):
-        config_files = self.possible_paths_to_cfg()
+    def read_all_config_files(self, cfg_file=None):
+        config_files = self.possible_paths_to_cfg(cfg_file)
 
         self.cfg_files = self.read(config_files)
 
@@ -616,7 +618,7 @@ class Config(configparser.ConfigParser):
         return self
 
     #///////////////////////////////////////////////////////////////////////////////
-    def possible_paths_to_cfg(self):
+    def possible_paths_to_cfg(self, cfg_file=None):
         """
             possible_paths_to_cfg()
             ________________________________________________________________________
@@ -648,8 +650,12 @@ class Config(configparser.ConfigParser):
                                 CST__KATALSYS_SUBDIR))
         res.append(normpath(ARGS.targetpath))
 
+
         cfg_localisation = [os.path.join(cfg_path, CST__DEFAULT_CONFIGFILE_NAME)
                             for cfg_path in res]
+
+        if cfg_file:
+            cfg_localisation.append(cfg_file)
 
         return cfg_localisation
 

--- a/katal/katal.py
+++ b/katal/katal.py
@@ -328,14 +328,14 @@ class Config(configparser.ConfigParser):
         self.read_parameters_from_cfgfile()
 
     def arguments_to_dict(self):
-        return {
-            'display': {
-                'verbosity': self.verbosity,
-            },
-            'source': {
-                'strict comparison': self.strictcmp
-            },
-        }
+        return_dict = {}
+        if self.verbosity is not None:
+            return_dict['display']['verbosity'] = self.verbosity
+
+        if self.strictcmp:
+            return_dict['source']['strict comparison'] =  self.strictcmp
+
+        return return_dict
 
     def check_args(self, parser):
         """
@@ -1431,7 +1431,7 @@ def action__new(targetname):
                                      CST__KATALSYS_SUBDIR,
                                      CST__DATABASE_NAME))
 
-    if ARGS.verbosity != 'none':
+    if CONFIG['display']['verbosity'] != 'none':
         answer = \
             input(("\nDo you want to download the default config file "
                    "into the expected directory ? (y/N) "))
@@ -1678,7 +1678,7 @@ def action__reset():
         LOGGER.warning("    ! no database found, nothing to do .")
         return
 
-    if ARGS.verbosity != 'none':
+    if CONFIG['display']['verbosity'] != 'none':
         answer = \
             input(("\nDo you really want to delete (=move to the katal trash directory)"
                    "the files in the target directory and the database (y/N) "))
@@ -2104,11 +2104,11 @@ def configure_loggers():
             formatter1 = logging.Formatter('%(levelname)s::%(asctime)s::  %(message)s')
             handler1.setFormatter(formatter1)
 
-            if ARGS.verbosity == 'none':
+            if CONFIG['display']['verbosity'] == 'none':
                 handler1.setLevel(logging.INFO) # To keep a record of what is done
-            elif ARGS.verbosity == 'normal':
+            elif CONFIG['display']['verbosity'] == 'normal':
                 handler1.setLevel(logging.INFO)
-            elif ARGS.verbosity == 'high':
+            elif CONFIG['display']['verbosity'] == 'high':
                 handler1.setLevel(logging.DEBUG)
 
             LOGGER.addHandler(handler1)
@@ -2128,11 +2128,11 @@ def configure_loggers():
     handler2 = logging.StreamHandler()
     handler2.setFormatter(formatter2)
 
-    if ARGS.verbosity == 'none':
+    if CONFIG['display']['verbosity'] == 'none':
         handler2.setLevel(logging.ERROR)
-    elif ARGS.verbosity == 'normal':
+    elif CONFIG['display']['verbosity'] == 'normal':
         handler2.setLevel(logging.INFO)
-    elif ARGS.verbosity == 'high':
+    elif CONFIG['display']['verbosity'] == 'high':
         handler2.setLevel(logging.DEBUG)
 
     LOGGER.addHandler(handler2)
@@ -2545,7 +2545,7 @@ def fill_select(debug_datatime=None):
                     # ... nothing : incompatibility with at least one filter :
                     number_of_discarded_files += 1
 
-                    if ARGS.verbosity == 'high':
+                    if CONFIG['display']['verbosity'] == 'high':
                         LOGGER.info("    - %s discarded \"%s\" "
                                     ": incompatibility with the filter(s)",
                                     prefix, fullname)
@@ -2563,7 +2563,7 @@ def fill_select(debug_datatime=None):
                         # <filename> :
                         number_of_discarded_files += 1
 
-                        if ARGS.verbosity == 'high':
+                        if CONFIG['display']['verbosity'] == 'high':
                             LOGGER.info("    - %s (similar hashid among the files to be copied, "
                                         "in the source directory) discarded \"%s\"",
                                         prefix, fullname)
@@ -2612,7 +2612,7 @@ def fill_select(debug_datatime=None):
                         # tobeadded is False : let's discard <filename> :
                         number_of_discarded_files += 1
 
-                        if ARGS.verbosity == 'high':
+                        if CONFIG['display']['verbosity'] == 'high':
                             LOGGER.info("    - %s (similar hashid in the database) "
                                         " discarded \"%s\"", prefix, fullname)
 
@@ -2944,7 +2944,7 @@ def main_actions():
         read_filters()
         action__select()
 
-        if ARGS.verbosity != 'none' and len(SELECT) > 0:
+        if CONFIG['display']['verbosity'] != 'none' and len(SELECT) > 0:
             answer = \
                 input("\nDo you want to update the target database and to {0} the selected "
                       "files into the target directory "
@@ -3588,7 +3588,7 @@ def thefilehastobeadded__db(filename, _size):
                 src_partialhashid,
                 src_hashid)
 
-    if not ARGS.strictcmp:
+    if not CONFIG['source']['strict comparison']:
         return (False, None, None)
 
     # (4) bit-to-bit comparision :

--- a/katal/katal.py
+++ b/katal/katal.py
@@ -88,6 +88,9 @@ CFG_PARAMETERS = None  # see documentation:configuration file
                        # parameters read from the configuration file.
                        # see the read_parameters_from_cfgfile() function
 
+CONFIG = None # centralize all config (command line + configuration file)
+              # see Config()
+
 INFOS_ABOUT_SRC_PATH = (None, None, None)  # initialized by show_infos_about_source_path()
                                            # ((int)total_size, (int)files_number, (dict)extensions)
 
@@ -273,7 +276,7 @@ class ConfigFileNotFoundError(FileNotFoundError):
         pass
 
 #///////////////////////////////////////////////////////////////////////////////
-class ConfigError(Exception):
+class ConfigError(configparser.Error):
     pass
 
 #///////////////////////////////////////////////////////////////////////////////
@@ -295,6 +298,376 @@ class ColorFormatter(logging.Formatter):
             record.color_end = ''
 
         return super().format(record)
+
+
+class Config(configparser.ConfigParser):
+    def __init__(self):
+        super().__init__(interpolation=configparser.ExtendedInterpolation())
+
+    def read_config(self):
+        self.read_command_line_arguments()
+
+        # TODO: download configfile
+        self.read_dict(self.default_config())    # Initialize the defaults value
+        self.read_all_config_files()
+        self.read_dict(self.arguments_to_dict()) # Modifications from command line
+
+        self.read_parameters_from_cfgfile()
+
+    def arguments_to_dict(self):
+        return {
+            'display': {
+                'verbosity': self.verbosity,
+            },
+            'tags': {
+                self.addtag: True,
+            },
+        }
+
+    def default_config(self):
+        return {
+        'source': {
+            'path': '.',
+            'eval': '*',
+        },
+        'target': {
+            'mode': 'copy',
+            'name of the target file': '%i.%e',
+        },
+        'log file': {
+            'use log file': True,
+            'name': 'katal.log',
+            'maximal size': 1e8,
+        },
+        'display': {
+            'target filename.max length on console': 30,
+            'source filename.max length on console': 40,
+            'hashid.max length on console': 20,
+            'tag.max length on console': 10,
+            'verbosity': 'debug',
+        },
+        'actions': {
+            'add': False,
+            'cleandbrm': False
+        },
+        'tags': {}
+    }
+
+    def read_all_config_files(self):
+        config_files = self.possible_paths_to_cfg()
+
+        LOGGER.debug("  = Parse following config files (if they exist):")
+        for f in config_files:
+            LOGGER.debug('   o config file "%s" (path : "%s")', f, normpath(f))
+
+        self.cfg_files = self.read(config_files)
+
+        if self.configfile:
+            LOGGER.info('  o config file given as a parameter : "%s" (path : '
+                        '"%s"', self.configfile, normpath(self.configfile))
+            try:
+                with open(self.configfile) as f:
+                    self.read_file(f)
+                    self.cfg_files.append(self.configfile)
+            except FileNotFoundError:
+                LOGGER.warning()
+                LOGGER.warning('  ! The config file "%s" (path : "%s") '
+                               "doesn't exist. ",
+                               self.configfile, normpath(self.configfile),
+                            color="red")
+
+        if not self.cfg_files:
+            LOGGER.warning('  ! No config file has been found, '
+                           'continuing with default values')
+            LOGGER.warning("    Use the -dlcfg/--downloaddefaultcfg option "
+                           "to download a default config file.")
+
+    def read_command_line_arguments(self):
+        """
+            read_command_line_arguments(self)
+            ________________________________________________________________________
+
+            Read the command line arguments.
+            ________________________________________________________________________
+
+            no PARAMETER
+
+            RETURNED VALUE
+                    return the argparse object.
+        """
+        parser = \
+        argparse.ArgumentParser(description="{0} v. {1}".format(__projectname__, __version__),
+                                epilog="{0} v. {1} ({2}), "
+                                        "a project by {3} "
+                                        "({4})".format(__projectname__,
+                                                        __version__,
+                                                        __license__,
+                                                        __author__,
+                                                        __email__),
+                                formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+
+        exclusive_group = parser.add_mutually_exclusive_group()
+
+        exclusive_group.add_argument('--add',
+                            action="store_true",
+                            help="# Select files according to what is described "
+                                "in the configuration file "
+                                "then add them to the target directory. "
+                                "This option can't be used with the --select one."
+                                "If you want more informations about the process, please "
+                                "use this option in combination with --infos .")
+
+        parser.add_argument('--addtag',
+                            type=str,
+                            help="# Add a tag to some file(s) in combination "
+                                "with the --to option. ")
+
+        parser.add_argument('-cfg', '--configfile',
+                            type=str,
+                            help="# Set the name of the config file, e.g. config.ini")
+
+        parser.add_argument('--cleandbrm',
+                            action="store_true",
+                            help="# Remove from the database the missing files in the target path.")
+
+        parser.add_argument('--copyto',
+                            type=str,
+                            help="# To be used with the --findtag parameter. Copy the found files "
+                                "into an export directory.")
+
+        parser.add_argument('-dlcfg', '--downloaddefaultcfg',
+                            choices=("local", "home",),
+                            help="# Download the default config file and overwrite the file having "
+                                "the same name. This is done before the script reads the parameters "
+                                "in the config file. Use 'local' to download in the current "
+                                "directory, 'home' to download in the user's HOME directory.")
+
+        parser.add_argument('--findtag',
+                            type=str,
+                            help="# Find the files in the target directory with the given tag. "
+                                "The tag is a simple string, not a regex.")
+
+        parser.add_argument('--infos',
+                            action="store_true",
+                            help="# Display informations about the source directory "
+                                "given in the configuration file. Help the --select/--add "
+                                "options to display more informations about the process : in "
+                                "this case, the --infos will be executed before --select/--add")
+
+        parser.add_argument('-n', '--new',
+                            type=str,
+                            help="# Create a new target directory")
+
+        parser.add_argument('--off',
+                            action="store_true",
+                            help="# Don't write anything into the target directory or into "
+                                "the database, except into the current log file. "
+                                "Use this option to simulate an operation : you get the messages "
+                                "but no file is modified on disk, no directory is created.")
+
+        parser.add_argument('--rebase',
+                            type=str,
+                            help="# Copy the current target directory into a new one : you "
+                                "rename the files in the target directory and in the database. "
+                                "First, use the --new option to create a new target directory, "
+                                "modify the .ini file of the new target directory "
+                                "(modify [target]name of the target files), "
+                                "then use --rebase with the name of the new target directory")
+
+        parser.add_argument('--reset',
+                            action="store_true",
+                            help="# Delete the database and the files in the target directory")
+
+        parser.add_argument('--rmnotags',
+                            action="store_true",
+                            help="# Remove all files without a tag")
+
+        parser.add_argument('--rmtags',
+                            action="store_true",
+                            help="# Remove all the tags of some file(s) in combination "
+                                "with the --to option. ")
+
+        exclusive_group.add_argument('-s', '--select',
+                            action="store_true",
+                            help="# Select files according to what is described "
+                                "in the configuration file "
+                                "without adding them to the target directory. "
+                                "This option can't be used with the --add one."
+                                "If you want more informations about the process, please "
+                                "use this option in combination with --infos .")
+
+        parser.add_argument('--settagsstr',
+                            type=str,
+                            help="# Give the tag to some file(s) in combination "
+                                "with the --to option. "
+                                "Overwrite the ancient tag string. "
+                                "If you want to empty the tags' string, please use a space, "
+                                "not an empty string : otherwise the parameter given "
+                                "to the script wouldn't be taken in account by the shell")
+
+        parser.add_argument('-si', '--sourceinfos',
+                            action="store_true",
+                            help="# Display informations about the source directory")
+
+        parser.add_argument('--strictcmp',
+                            action="store_true",
+                            help="# To be used with --add or --select. Force a bit-to-bit comparision"
+                                "between files whose hashid-s is equal.")
+
+        parser.add_argument('--targetpath',
+                            type=str,
+                            default=".",
+                            help="# Target path, usually '.' . If you set path to . (=dot character)"
+                                ", it means that the source path is the current directory"
+                                " (=the directory where the script katal.py has been launched)")
+
+        parser.add_argument('-ti', '--targetinfos',
+                            action="store_true",
+                            help="# Display informations about the target directory")
+
+        parser.add_argument('-tk', '--targetkill',
+                            type=str,
+                            help="# Kill (=move to the trash directory) one file from "
+                                "the target directory."
+                                "DO NOT GIVE A PATH, just the file's name, "
+                                "without the path to the target directory")
+
+        parser.add_argument('--to',
+                            type=str,
+                            help="# Give the name of the file(s) concerned by --settagsstr. "
+                            "wildcards accepted; e.g. to select all .py files, use '*.py' . "
+                            "Please DON'T ADD the path to the target directory, only the filenames")
+
+        parser.add_argument('--usentfsprefix',
+                            action="store_true",
+                            help="# Force the script to prefix filenames by a special string "
+                                "required by the NTFS for long filenames, namely \\\\?\\")
+
+        parser.add_argument('--verbosity',
+                            choices=("none", "normal", "high"),
+                            default='normal',
+                            help="# Console verbosity : "
+                                "'none'=no output to the console, no question asked on the console; "
+                                "'normal'=messages to the console "
+                                "and questions asked on the console; "
+                                "'high'=display discarded files. A question may be asked only by "
+                                "using the following arguments : "
+                                "--new, --rebase, --reset and --select")
+
+        parser.add_argument('--version',
+                            action='version',
+                            version="{0} v. {1}".format(__projectname__, __version__),
+                            help="# Show the version and exit")
+
+        parser.add_argument('--whatabout',
+                            type=str,
+                            help="# Say if the file[the files in a directory] already in the "
+                                "given as a parameter is in the target directory "
+                                "notwithstanding its name.")
+
+        return parser.parse_args(namespace=self)
+
+    #///////////////////////////////////////////////////////////////////////////////
+    def possible_paths_to_cfg(self):
+        """
+            possible_paths_to_cfg()
+            ________________________________________________________________________
+
+            return a list of the (str)paths to the config file, without the name
+            of the file.
+
+            The first element of the list is the local directory + ".katal",
+            the last element of the list is ~ + .katal .
+            ________________________________________________________________________
+
+            NO PARAMETER.
+
+            RETURNED VALUE : the expected list of strings.
+        """
+        res = []
+
+        res.append(os.path.join(normpath("~"), ".katal"))
+        if CST__XDG_CONFIG:
+            res.append(CST__XDG_CONFIG)
+
+        if CST__PLATFORM == 'Windows':
+            res.append(os.path.join(normpath("~"),
+                                    "Local Settings",
+                                    "Application Data",
+                                    "katal"))
+
+        res.append(os.path.join(normpath(ARGS.targetpath),
+                                CST__KATALSYS_SUBDIR))
+        res.append(normpath(ARGS.targetpath))
+
+        cfg_localisation = [os.path.join(cfg_path, CST__DEFAULT_CONFIGFILE_NAME)
+                            for cfg_path in res]
+
+        return cfg_localisation
+
+    #///////////////////////////////////////////////////////////////////////////////
+    def read_parameters_from_cfgfile(self):
+        """
+            read_parameters_from_cfgfile()
+            ________________________________________________________________________
+
+            Read the configfile and return the parser. If an error occured, a
+            ConfigError is raised.
+
+            If the mode is set to 'nocopy', parser["target"]["name of the target files"]
+            is set to "%i" .
+            ________________________________________________________________________
+
+            PARAMETER
+                    o _configfile_name       : (str) config file name (e.g. katal.ini)
+
+            RETURNED VALUE
+                    The expected configparser.ConfigParser object=.
+            EXCEPTION
+                    A ConfigError if an error occured while reading the configuration file
+
+        """
+        global USE_LOGFILE
+
+        parser = self
+        try:
+            USE_LOGFILE = parser["log file"].getboolean("use log file")
+            # just to check the existence of the following values in the configuration file :
+            parser["log file"]["maximal size"]
+            parser["log file"]["name"]
+            parser["target"]["name of the target files"]
+            parser["target"]["mode"]
+            parser["source"]["eval"]
+            parser["display"]["target filename.max length on console"]
+            parser["display"]["hashid.max length on console"]
+            parser["display"]["tag.max length on console"]
+            parser["display"]["source filename.max length on console"]
+            parser["source"]["path"]
+        except KeyError as exception:
+            LOGGER.error("  ! An error occured while reading "
+                        "config files.", color="red")
+            LOGGER.warning("  ! Your configuration file lacks a specific value : \"%s\".",
+                        exception, color="red")
+            LOGGER.warning("  ... you should download a new default config file : "
+                        "see -dlcfg/--downloaddefaultcfg option",
+                        color="red")
+            raise ConfigError
+        except configparser.Error as exception:
+            LOGGER.exception("  ! An error occured while reading "
+                "the config file \"%s\".", _configfile_name,
+                color="red", exc_info=True)
+            raise ConfigError
+
+        if parser["target"]["mode"] == 'nocopy':
+            parser["target"]["name of the target files"] = "%i"
+
+            LOGGER.info('  *  since "mode"=="nocopy", the value of "[target]name of the target files" ',
+                        color="cyan")
+            LOGGER.info("     is neutralized and set to '%i' (i.e. the database index : '1', '2', ...)",
+                        color="cyan")
+
+    #///////////////////////////////////////////////////////////////////////////////
+
 
 def action__add():
     """
@@ -578,7 +951,7 @@ def action__infos():
         RETURNED VALUE
                 (int) 0 if ok, -1 if an error occured
     """
-    LOGGER.info("  = informations =")
+    LOGGER.info("  = informations =", color="white")
     show_infos_about_source_path()
     return show_infos_about_target_path()
 
@@ -1217,10 +1590,6 @@ def add_keywords_in_targetstr(srcstring,
 
         see the available keywords in the documentation.
             (see documentation:configuration file)
-
-        caveat : in the .ini files, '%' have to be written twice (as in
-                 '%%p', e.g.) but Python reads it as if only one % was
-                 written.
         ________________________________________________________________________
 
         PARAMETERS
@@ -1228,7 +1597,10 @@ def add_keywords_in_targetstr(srcstring,
                 o hashid                       : (str)
                 o filename_no_extens           : (str)
                 o path                         : (str
-                o extension                    : (str)
+                o extensiont : in the .ini files, '%' have to be written twice (as in
+                                 '%%p', e.g.) but Python reads it as if only one % was
+                                                  written.
+                                                  : (str)
                 o _size                        : (int)
                 o date                         : (str) see CST__DTIME_FORMAT
                 o database_index               : (int)
@@ -1307,8 +1679,8 @@ def check_args():
         no PARAMETER, no RETURNED VALUE
     """
     # --select and --add can't be used simultaneously.
-    if ARGS.add is True and ARGS.select is True:
-        raise KatalError("--select and --add can't be used simultaneously")
+    # Already checked with the mutually exclusive group in the argparse
+    # definition
 
     # --settagsstr must be used with --to :
     if ARGS.settagsstr and not ARGS.to:
@@ -2076,12 +2448,14 @@ def main():
         o  sys.exit(-2) is called if a KatalError exception is raised
         o  sys.exit(-3) is called if another exception is raised
     """
-    global ARGS
+    global ARGS, CONFIG
 
     timestamp_start = datetime.now()
 
     try:
-        ARGS = read_command_line_arguments()
+        CONFIG = Config()
+        CONFIG.read_command_line_arguments()
+        ARGS = CONFIG
         check_args()
         main_loggers()
 
@@ -2261,25 +2635,11 @@ def main_warmup(timestamp_start):
         return
 
     #...........................................................................
-    # let's find a config file to be read :
+    # let's read the config files:
     try:
-        configfile_name = where_is_the_configfile()
-
-    except ConfigFileNotFoundError:
-        if ARGS.downloaddefaultcfg is None:
-            LOGGER.warning(msg_please_use_dlcfg, color="red")
-            sys.exit(-1)
-        else:
-            LOGGER.info("  ! Can't find any configuration file, but you used the "
-                "--downloaddefaultcfg option.")
-            return
-
-
-    #...........................................................................
-    # let's read the config file :
-    try:
-        CFG_PARAMETERS = read_parameters_from_cfgfile(configfile_name)
-    except ConfigError:
+        CONFIG.read_config()
+        CFG_PARAMETERS = CONFIG
+    except configparser.Error:
         # ill-formed config file :
         sys.exit(-1)
     else:
@@ -2312,7 +2672,7 @@ def main_warmup(timestamp_start):
 
     #...........................................................................
     # we show the following informations :
-    for path, info in ((configfile_name, "config file"),
+    for path, info in ((CONFIG.cfg_files, "config file"),
                        (os.path.join(normpath(ARGS.targetpath),
                                      CST__KATALSYS_SUBDIR, CST__TRASH_SUBSUBDIR), "trash subdir"),
                        (os.path.join(normpath(ARGS.targetpath),
@@ -2426,292 +2786,6 @@ def normpath(path):
         res = "\\\\?\\"+res
 
     return res
-
-#///////////////////////////////////////////////////////////////////////////////
-def read_command_line_arguments():
-    """
-        read_command_line_arguments()
-        ________________________________________________________________________
-
-        Read the command line arguments.
-        ________________________________________________________________________
-
-        no PARAMETER
-
-        RETURNED VALUE
-                return the argparse object.
-    """
-    parser = \
-      argparse.ArgumentParser(description="{0} v. {1}".format(__projectname__, __version__),
-                              epilog="{0} v. {1} ({2}), "
-                                     "a project by {3} "
-                                     "({4})".format(__projectname__,
-                                                    __version__,
-                                                    __license__,
-                                                    __author__,
-                                                    __email__),
-                              formatter_class=argparse.ArgumentDefaultsHelpFormatter)
-
-    parser.add_argument('--add',
-                        action="store_true",
-                        help="# Select files according to what is described "
-                             "in the configuration file "
-                             "then add them to the target directory. "
-                             "This option can't be used with the --select one."
-                             "If you want more informations about the process, please "
-                             "use this option in combination with --infos .")
-
-    parser.add_argument('--addtag',
-                        type=str,
-                        help="# Add a tag to some file(s) in combination "
-                             "with the --to option. ")
-
-    parser.add_argument('-cfg', '--configfile',
-                        type=str,
-                        help="# Set the name of the config file, e.g. config.ini")
-
-    parser.add_argument('--cleandbrm',
-                        action="store_true",
-                        help="# Remove from the database the missing files in the target path.")
-
-    parser.add_argument('--copyto',
-                        type=str,
-                        help="# To be used with the --findtag parameter. Copy the found files "
-                             "into an export directory.")
-
-    parser.add_argument('-dlcfg', '--downloaddefaultcfg',
-                        choices=("local", "home",),
-                        help="# Download the default config file and overwrite the file having "
-                             "the same name. This is done before the script reads the parameters "
-                             "in the config file. Use 'local' to download in the current "
-                             "directory, 'home' to download in the user's HOME directory.")
-
-    parser.add_argument('--findtag',
-                        type=str,
-                        help="# Find the files in the target directory with the given tag. "
-                             "The tag is a simple string, not a regex.")
-
-    parser.add_argument('--infos',
-                        action="store_true",
-                        help="# Display informations about the source directory "
-                             "given in the configuration file. Help the --select/--add "
-                             "options to display more informations about the process : in "
-                             "this case, the --infos will be executed before --select/--add")
-
-    parser.add_argument('-n', '--new',
-                        type=str,
-                        help="# Create a new target directory")
-
-    parser.add_argument('--off',
-                        action="store_true",
-                        help="# Don't write anything into the target directory or into "
-                             "the database, except into the current log file. "
-                             "Use this option to simulate an operation : you get the messages "
-                             "but no file is modified on disk, no directory is created.")
-
-    parser.add_argument('--rebase',
-                        type=str,
-                        help="# Copy the current target directory into a new one : you "
-                             "rename the files in the target directory and in the database. "
-                             "First, use the --new option to create a new target directory, "
-                             "modify the .ini file of the new target directory "
-                             "(modify [target]name of the target files), "
-                             "then use --rebase with the name of the new target directory")
-
-    parser.add_argument('--reset',
-                        action="store_true",
-                        help="# Delete the database and the files in the target directory")
-
-    parser.add_argument('--rmnotags',
-                        action="store_true",
-                        help="# Remove all files without a tag")
-
-    parser.add_argument('--rmtags',
-                        action="store_true",
-                        help="# Remove all the tags of some file(s) in combination "
-                             "with the --to option. ")
-
-    parser.add_argument('-s', '--select',
-                        action="store_true",
-                        help="# Select files according to what is described "
-                             "in the configuration file "
-                             "without adding them to the target directory. "
-                             "This option can't be used with the --add one."
-                             "If you want more informations about the process, please "
-                             "use this option in combination with --infos .")
-
-    parser.add_argument('--settagsstr',
-                        type=str,
-                        help="# Give the tag to some file(s) in combination "
-                             "with the --to option. "
-                             "Overwrite the ancient tag string. "
-                             "If you want to empty the tags' string, please use a space, "
-                             "not an empty string : otherwise the parameter given "
-                             "to the script wouldn't be taken in account by the shell")
-
-    parser.add_argument('-si', '--sourceinfos',
-                        action="store_true",
-                        help="# Display informations about the source directory")
-
-    parser.add_argument('--strictcmp',
-                        action="store_true",
-                        help="# To be used with --add or --select. Force a bit-to-bit comparision"
-                             "between files whose hashid-s is equal.")
-
-    parser.add_argument('--targetpath',
-                        type=str,
-                        default=".",
-                        help="# Target path, usually '.' . If you set path to . (=dot character)"
-                             ", it means that the source path is the current directory"
-                             " (=the directory where the script katal.py has been launched)")
-
-    parser.add_argument('-ti', '--targetinfos',
-                        action="store_true",
-                        help="# Display informations about the target directory")
-
-    parser.add_argument('-tk', '--targetkill',
-                        type=str,
-                        help="# Kill (=move to the trash directory) one file from "
-                             "the target directory."
-                             "DO NOT GIVE A PATH, just the file's name, "
-                             "without the path to the target directory")
-
-    parser.add_argument('--to',
-                        type=str,
-                        help="# Give the name of the file(s) concerned by --settagsstr. "
-                        "wildcards accepted; e.g. to select all .py files, use '*.py' . "
-                        "Please DON'T ADD the path to the target directory, only the filenames")
-
-    parser.add_argument('--usentfsprefix',
-                        action="store_true",
-                        help="# Force the script to prefix filenames by a special string "
-                             "required by the NTFS for long filenames, namely \\\\?\\")
-
-    parser.add_argument('--verbosity',
-                        choices=("none", "normal", "high"),
-                        default='normal',
-                        help="# Console verbosity : "
-                             "'none'=no output to the console, no question asked on the console; "
-                             "'normal'=messages to the console "
-                             "and questions asked on the console; "
-                             "'high'=display discarded files. A question may be asked only by "
-                             "using the following arguments : "
-                             "--new, --rebase, --reset and --select")
-
-    parser.add_argument('--version',
-                        action='version',
-                        version="{0} v. {1}".format(__projectname__, __version__),
-                        help="# Show the version and exit")
-
-    parser.add_argument('--whatabout',
-                        type=str,
-                        help="# Say if the file[the files in a directory] already in the "
-                             "given as a parameter is in the target directory "
-                             "notwithstanding its name.")
-
-    return parser.parse_args()
-
-#///////////////////////////////////////////////////////////////////////////////
-def possible_paths_to_cfg():
-    """
-        possible_paths_to_cfg()
-        ________________________________________________________________________
-
-        return a list of the (str)paths to the config file, without the name
-        of the file.
-
-          The first element of the list is the local directory + ".katal",
-        the last element of the list is ~ + .katal .
-        ________________________________________________________________________
-
-        NO PARAMETER.
-
-        RETURNED VALUE : the expected list of strings.
-    """
-    res = []
-
-    res.append(normpath(ARGS.targetpath))
-    res.append(os.path.join(normpath(ARGS.targetpath),
-                            CST__KATALSYS_SUBDIR))
-
-    if CST__PLATFORM == 'Windows':
-        res.append(os.path.join(normpath("~"),
-                                "Local Settings",
-                                "Application Data",
-                                "katal"))
-
-    res.append(CST__XDG_CONFIG)
-
-    res.append(os.path.join(normpath("~"),
-                            ".katal"))
-
-    return res
-
-#///////////////////////////////////////////////////////////////////////////////
-def read_parameters_from_cfgfile(_configfile_name):
-    """
-        read_parameters_from_cfgfile()
-        ________________________________________________________________________
-
-        Read the configfile and return the parser. If an error occured, a
-        ConfigError is raised.
-
-        If the mode is set to 'nocopy', parser["target"]["name of the target files"]
-        is set to "%i" .
-        ________________________________________________________________________
-
-        PARAMETER
-                o _configfile_name       : (str) config file name (e.g. katal.ini)
-
-        RETURNED VALUE
-                The expected configparser.ConfigParser object=.
-        EXCEPTION
-                A ConfigError if an error occured while reading the configuration file
-
-    """
-    global USE_LOGFILE
-
-    parser = configparser.ConfigParser(interpolation=configparser.ExtendedInterpolation())
-
-    try:
-        parser.read(_configfile_name)
-        USE_LOGFILE = parser["log file"].getboolean("use log file")
-        # just to check the existence of the following values in the configuration file :
-        parser["log file"]["maximal size"]
-        parser["log file"]["name"]
-        parser["target"]["name of the target files"]
-        parser["target"]["mode"]
-        parser["source"]["eval"]
-        parser["display"]["target filename.max length on console"]
-        parser["display"]["hashid.max length on console"]
-        parser["display"]["tag.max length on console"]
-        parser["display"]["source filename.max length on console"]
-        parser["source"]["path"]
-    except KeyError as exception:
-        LOGGER.error("  ! An error occured while reading "
-                       "the config file \"%s\".", _configfile_name,
-                        color="red")
-        LOGGER.warning("  ! Your configuration file lacks a specific value : \"%s\".",
-                       exception, color="red")
-        LOGGER.warning("  ... you should download a new default config file : "
-                       "see -dlcfg/--downloaddefaultcfg option",
-                       color="red")
-        raise ConfigError
-    except Exception as exception:
-        LOGGER.exception("  ! An error occured while reading "
-            "the config file \"%s\".", _configfile_name,
-            color="red", exc_info=True)
-        raise ConfigError
-
-    if parser["target"]["mode"] == 'nocopy':
-        parser["target"]["name of the target files"] = "%i"
-
-        LOGGER.info("  *  since 'mode'=='nocopy', the value of \"[target]name of the target files\" ",
-                    color="cyan")
-        LOGGER.info("     is neutralized and set to '%i' (i.e. the database index : '1', '2', ...)",
-                    color="cyan")
-
-    return parser
 
 #///////////////////////////////////////////////////////////////////////////////
 def read_filters():
@@ -3184,15 +3258,12 @@ def thefilehastobeadded__filters(filename, _size, date):
         # eval() IS a dangerous function : see the note about CST__AUTHORIZED_EVALCHARS.
         for char in evalstr:
             if char not in CST__AUTHORIZED_EVALCHARS:
-                raise KatalError("Error in configuration file : "
-                                 "trying to compute the \"{0}\" string; "
-                                 "wrong character '{1}'({2}) "
-                                 "used in the string to be evaluated. "
-                                 "Authorized " "characters are "
-                                 "{3}".format(evalstr,
-                                              char,
-                                              unicodedata.name(char),
-                                              "|"+"|".join(CST__AUTHORIZED_EVALCHARS)))
+                raise KatalError(
+                    'Error in configuration file : trying to compute the "{0}" string; '
+                    "wrong character '{1}'({2}) used in the string to be evaluated. "
+                    "Authorized characters are {3}".format(
+                        evalstr, char, unicodedata.name(char),
+                        "|"+"|".join(CST__AUTHORIZED_EVALCHARS)))
         return eval(evalstr)
 
     except Exception as exception:
@@ -3405,65 +3476,8 @@ def welcome_in_logfile(timestamp_start):
         "(path : \"%s\")", ARGS.targetpath,
                                   normpath(ARGS.targetpath))
 
+
 #///////////////////////////////////////////////////////////////////////////////
-def where_is_the_configfile():
-    """
-        where_is_the_configfile()
-        ________________________________________________________________________
-
-        Return the config file name from ARGS.configfile or from the paths
-        returned by possible_paths_to_cfg() .
-        If not config file path has be found, a ConfigFileNotFoundError
-        is raised.
-        ________________________________________________________________________
-
-        no PARAMETER
-
-        RETURNED VALUE : str(filename)
-
-        EXCEPTION: ConfigFileNotFoundError if no file found
-    """
-    msg_please_use_dlcfg = \
-     ("    ! error : can't find any config file !\n"
-      "    Use the -dlcfg/--downloaddefaultcfg option to download a default config file.")
-
-    if not ARGS.configfile:
-        # no config file given as a parameter, let's guess where it is :
-
-        for cfg_path in possible_paths_to_cfg():
-            LOGGER.info("  * trying to find a config file in \"%s\"...", cfg_path)
-
-            path = os.path.join(cfg_path, CST__DEFAULT_CONFIGFILE_NAME)
-            if os.path.exists(path):
-                configfile_name = path
-                LOGGER.info("   ... ok a config file has been found, let's try to read it...")
-                LOGGER.info("  * config file name : \"%s\" (path : \"%s\")",
-                            configfile_name, normpath(configfile_name))
-                break
-
-        else:
-            raise ConfigFileNotFoundError
-
-    else:
-        # A config file has been given as a parameter :
-        configfile_name = ARGS.configfile
-
-        LOGGER.info("  * config file given as a parameter : \"%s\" "
-                    "(path : \"%s\"", configfile_name, normpath(configfile_name))
-
-        if not os.path.exists(normpath(configfile_name)) and ARGS.new is None:
-            LOGGER.warning("  ! The config file \"%s\" (path : \"%s\") "
-                           "doesn't exist. ", configfile_name, normpath(configfile_name),
-                           color="red")
-
-            if not ARGS.downloaddefaultcfg:
-                LOGGER.warning(msg_please_use_dlcfg, color="red")
-
-            raise ConfigFileNotFoundError
-
-
-    return configfile_name
-
 #///////////////////////////////////////////////////////////////////////////////
 #/////////////////////////////// STARTING POINT ////////////////////////////////
 #///////////////////////////////////////////////////////////////////////////////

--- a/tests/cfgfile1.ini
+++ b/tests/cfgfile1.ini
@@ -35,7 +35,7 @@ size : =2
 mode : copy
 
 # the new name for the target files is created using some keywords :
-name of the target files : %%dd__%%i.%%e
+name of the target files : %dd__%i.%e
 
 tags : 
 

--- a/tests/cfgfile2.ini
+++ b/tests/cfgfile2.ini
@@ -34,7 +34,7 @@ size : =2
 mode : copy
 
 # the new name for the target files is created using some keywords :
-name of the target files : %%dd__%%i.%%e
+name of the target files : %dd__%i.%e
 
 tags : 
 

--- a/tests/cfgfile3.ini
+++ b/tests/cfgfile3.ini
@@ -37,7 +37,7 @@ name : .*\.5$
 mode : copy
 
 # the new name for the target files is created using some keywords :
-name of the target files : %%dd__%%i.%%e
+name of the target files : %dd__%i.%e
 
 tags : 
 

--- a/tests/cfgfile4.ini
+++ b/tests/cfgfile4.ini
@@ -40,7 +40,7 @@ name : ddddd.6
 mode : copy
 
 # the new name for the target files is created using some keywords :
-name of the target files : %%dd__%%i.%%e
+name of the target files : %dd__%i.%e
 
 tags : 
 

--- a/tests/cfgfile5.ini
+++ b/tests/cfgfile5.ini
@@ -34,7 +34,7 @@ iname : ^c.5$
 mode : copy
 
 # the new name for the target files is created using some keywords :
-name of the target files : %%dd__%%i.%%e
+name of the target files : %dd__%i.%e
 
 tags : 
 

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -52,8 +52,9 @@ class Tests(unittest.TestCase):
 
 		Test of the katal.py::fill_select() function.
         """
-        katal.ARGS.configfile = os.path.join("tests", "cfgfile1.ini")
-        katal.CFG_PARAMETERS = katal.read_parameters_from_cfgfile(katal.ARGS.configfile)
+        config = katal.Config()
+        config.read(os.path.join("tests", "cfgfile1.ini"))
+        katal.CFG_PARAMETERS = config
         katal.SOURCE_PATH = os.path.join("tests", "data1")
         katal.read_filters()
         katal.fill_select()
@@ -71,9 +72,9 @@ class Tests(unittest.TestCase):
 
 		Test of the katal.py::fill_select() function.
         """
-        katal.ARGS.configfile = os.path.join("tests", "cfgfile2.ini")
-        katal.CFG_PARAMETERS = katal.read_parameters_from_cfgfile(katal.ARGS.configfile)
-        katal.SOURCE_PATH = os.path.join("tests", "data1")
+        config = katal.Config()
+        config.read(os.path.join("tests", "cfgfile2.ini"))
+        katal.CFG_PARAMETERS = config
         katal.read_filters()
         katal.fill_select()
 
@@ -90,8 +91,9 @@ class Tests(unittest.TestCase):
 
 		Test of the katal.py::fill_select() function.
         """
-        katal.ARGS.configfile = os.path.join("tests", "cfgfile3.ini")
-        katal.CFG_PARAMETERS = katal.read_parameters_from_cfgfile(katal.ARGS.configfile)
+        config = katal.Config()
+        config.read(os.path.join("tests", "cfgfile3.ini"))
+        katal.CFG_PARAMETERS = config
         katal.SOURCE_PATH = os.path.join("tests", "data1")
         katal.read_filters()
         katal.fill_select()
@@ -115,8 +117,9 @@ class Tests(unittest.TestCase):
 
 		Test of the katal.py::fill_select() function.
         """
-        katal.ARGS.configfile = os.path.join("tests", "cfgfile4.ini")
-        katal.CFG_PARAMETERS = katal.read_parameters_from_cfgfile(katal.ARGS.configfile)
+        config = katal.Config()
+        config.read(os.path.join("tests", "cfgfile4.ini"))
+        katal.CFG_PARAMETERS = config
         katal.SOURCE_PATH = os.path.join("tests", "data1")
         katal.read_filters()
         katal.fill_select()
@@ -134,8 +137,9 @@ class Tests(unittest.TestCase):
 
 		Test of the katal.py::fill_select() function.
         """
-        katal.ARGS.configfile = os.path.join("tests", "cfgfile5.ini")
-        katal.CFG_PARAMETERS = katal.read_parameters_from_cfgfile(katal.ARGS.configfile)
+        config = katal.Config()
+        config.read(os.path.join("tests", "cfgfile5.ini"))
+        katal.CFG_PARAMETERS = config
         katal.SOURCE_PATH = os.path.join("tests", "data1")
         katal.read_filters()
         katal.fill_select()

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -53,8 +53,10 @@ class Tests(unittest.TestCase):
 		Test of the katal.py::fill_select() function.
         """
         config = katal.Config()
-        config.read(os.path.join("tests", "cfgfile1.ini"))
+        config.read_config(args=None, cfg_file=os.path.join("tests", "cfgfile1.ini"))
         katal.CFG_PARAMETERS = config
+        katal.ARGS = config
+        katal.CONFIG = config
         katal.SOURCE_PATH = os.path.join("tests", "data1")
         katal.read_filters()
         katal.fill_select()
@@ -73,8 +75,10 @@ class Tests(unittest.TestCase):
 		Test of the katal.py::fill_select() function.
         """
         config = katal.Config()
-        config.read(os.path.join("tests", "cfgfile2.ini"))
+        config.read_config(args=None, cfg_file=os.path.join("tests", "cfgfile2.ini"))
         katal.CFG_PARAMETERS = config
+        katal.ARGS = config
+        katal.CONFIG = config
         katal.read_filters()
         katal.fill_select()
 
@@ -92,8 +96,10 @@ class Tests(unittest.TestCase):
 		Test of the katal.py::fill_select() function.
         """
         config = katal.Config()
-        config.read(os.path.join("tests", "cfgfile3.ini"))
+        config.read_config(args=None, cfg_file=os.path.join("tests", "cfgfile3.ini"))
         katal.CFG_PARAMETERS = config
+        katal.ARGS = config
+        katal.CONFIG = config
         katal.SOURCE_PATH = os.path.join("tests", "data1")
         katal.read_filters()
         katal.fill_select()
@@ -118,7 +124,9 @@ class Tests(unittest.TestCase):
 		Test of the katal.py::fill_select() function.
         """
         config = katal.Config()
-        config.read(os.path.join("tests", "cfgfile4.ini"))
+        katal.ARGS = config
+        katal.CONFIG = config
+        config.read_config(args=None, cfg_file=os.path.join("tests", "cfgfile4.ini"))
         katal.CFG_PARAMETERS = config
         katal.SOURCE_PATH = os.path.join("tests", "data1")
         katal.read_filters()
@@ -138,7 +146,9 @@ class Tests(unittest.TestCase):
 		Test of the katal.py::fill_select() function.
         """
         config = katal.Config()
-        config.read(os.path.join("tests", "cfgfile5.ini"))
+        katal.ARGS = config
+        katal.CONFIG = config
+        config.read_config(args=None, cfg_file=os.path.join("tests", "cfgfile5.ini"))
         katal.CFG_PARAMETERS = config
         katal.SOURCE_PATH = os.path.join("tests", "data1")
         katal.read_filters()


### PR DESCRIPTION
Je continue sur ma lancée, et maintenant, je modifie la façon dont la configuration est lue.
J'ai regroupé dans une seule classe toute la logique correspondante, et j'ai unifié la lecture de la ligne de commande et du fichier de config. Cela permet : 
- d'avoir des valeurs par défaut. On n'est pas obligé de tous mettre dans katal.ini 
- d'avoir de l'héritage entre fichier de config. On peu mettre des valeurs par défaut, ou même définir des filtres dans `~/.katal/katal.ini`, puis les modifier dans `target/katal.ini` 
  - de modifier la configuration par la ligne de commande. Typiquement, on peut désormais spécifier la verbosité dans le fichier de config, puis la modifier en ligne de commande
  - de faire un peu plus propre et plus facilement extensible.

J'ai gardées les anciennes méthodes pour `ARGS` et `CFG_PARAMETER`, ce qui m'évite de réécrire tous le fichier, mais désormais, les nouveau accès à la configuration devrait se faire par `CONFIG`.

J'espère que ce n'est pas trop gros.
