### PR TITLE
Modification the way file are representated

### DIFF
--- a/katal/katal.ini
+++ b/katal/katal.ini
@@ -93,25 +93,35 @@ mode : copy
 #
 #   %h  : hashid (e.g. GwM5NKzoZ76oPAbWwX7od0pI66xZrOHI7TWIggx+xFk=)
 #
-#   %f  : source name (with the path), without the extension
+#   %n  : basename, without the extension (eg. my+file) 
 #
-#   %ff : source name (with the path), without the extension
+#   %nn : basename, without the extension (eg. my_file
+#
+#   %f  : source name (with the full path), without the extension (eg. /home/user/my+file)
+#
+#   %ff : source name (with the full path), without the extension (eg. _home_user_my_file)
 #          [see below, no forbidden characters]
 #
-#   %p  : source path
+#   %p  : full source path(eg. /home/user/my+file.ext)
 #
-#   %pp : source path
+#   %pp : full source path (eg. _home_user_my_file_ext)
 #          [see below, no forbidden characters]
 #
-#   %e  : source extension, without the dot character (e.g. jpg / no dot character !)
+#   %e  : source extension, without the dot character (eg. ext) 
 #
-#   %ee : source extension, without the dot character (e.g. jpg / no dot character !)
+#   %ee : source extension, without the dot character (eg. ext)
 #          [see below, no forbidden characters]
 #
 #   %s  : size (e.g. 123)
+#  
+#   %d(format)  : date, by passing format to strftime (eg. %d(%Y %b) -> 2015 Sep)
 #
-#   %dd : date (e.g. 2015_09_25_06_50)
+#   %dd(format) : date, by passing format to strftime (eg. %d(%Y %b) -> 2015_Sep)
 #          [see below, no forbidden characters]
+#
+#   %Y  : year (eg. 2015)
+#   %m  : month (eg. 09)
+#   %d  : day (eg. 27)
 #
 #   %i  : database index (e.g. 123)
 #

--- a/katal/katal.ini
+++ b/katal/katal.ini
@@ -26,7 +26,7 @@ path : .
 eval : filter1
 
 # Force a bit-to-bit comparision between files whose hashid-s is equal.
-strict comparison : False
+strict comparison : True
 
 # Read all files, including hidden ones
 read hidden files: False

--- a/katal/katal.ini
+++ b/katal/katal.ini
@@ -29,7 +29,7 @@ eval : filter1
 strict comparison : False
 
 [source.filter1]
-# You may use the following filters : 'name', 'iname', 'date', 'size' and 'name not existing'
+# You may use the following filters : 'name', 'iname', 'date', 'size' and 'external program'
 #
 # example : all .jpg(.JPG, .Jpg...) files modified after 2015-09-17 01:27 and bigger than 1 Mb
 #       iname : .*\.jpg$
@@ -49,9 +49,9 @@ strict comparison : False
 #
 #       size : =1Mo
 #
-#       name not existing : %%f.png -> will not copy image.jpg if image.png already exists
-#       'name not existing' is a string  with the same special character expansion as for creating target name 
-#       BEWARE: %%i cannot be used, and so this filter won't work with mode=nocopy
+#       external program : ./my_test %s -v -> the command by 
+#               Run the command by substituing %s by the name of the file
+#               If the return code is 0, the file is keeped, else it is rejected
 #
 # Use 'name' for a case sensitive search, 'iname' for a case insensitive search.
 #

--- a/katal/katal.ini
+++ b/katal/katal.ini
@@ -28,6 +28,9 @@ eval : filter1
 # Force a bit-to-bit comparision between files whose hashid-s is equal.
 strict comparison : False
 
+# Read all files, including hidden ones
+read hidden files: False
+
 [source.filter1]
 # You may use the following filters : 'name', 'iname', 'date', 'size' and 'external program'
 #

--- a/katal/katal.ini
+++ b/katal/katal.ini
@@ -96,18 +96,24 @@ mode : copy
 #
 #   %h  : hashid (e.g. GwM5NKzoZ76oPAbWwX7od0pI66xZrOHI7TWIggx+xFk=)
 #
-#   %n  : basename, without the extension (eg. my+file) 
-#
-#   %nn : basename, without the extension (eg. my_file
-#
-#   %f  : source name (with the full path), without the extension (eg. /home/user/my+file)
-#
-#   %ff : source name (with the full path), without the extension (eg. _home_user_my_file)
+#   %n  : name relative to the source, with the extension (eg. subdir/my+file.ext) 
+#         %n = %r/%f.%e
+#   %nn : name relative to the source, with the extension (eg. subdir/my+file.ext) 
 #          [see below, no forbidden characters]
 #
-#   %p  : full source path(eg. /home/user/my+file.ext)
+#   %r  : relative directory to the source (eg. subdir)
 #
-#   %pp : full source path (eg. _home_user_my_file_ext)
+#   %rr : relative directory to the source (eg. subdir)
+#          [see below, no forbidden characters]
+#
+#   %f  : basename, without the extension (eg. my+file)
+#
+#   %ff : base name, without the extension (eg. my_file)
+#          [see below, no forbidden characters]
+#
+#   %p  : full source path(eg. /home/user/subdir/my+file.ext)
+#
+#   %pp : full source path (eg. _home_user_subdir_my_file_ext)
 #          [see below, no forbidden characters]
 #
 #   %e  : source extension, without the dot character (eg. ext) 
@@ -121,6 +127,8 @@ mode : copy
 #
 #   %dd(format) : date, by passing format to strftime (eg. %d(%Y %b) -> 2015_Sep)
 #          [see below, no forbidden characters]
+#
+#   %dd = %dd(%Y_%m_%d_%H_%M) (eg. 2015_09_28_17_06)
 #
 #   %Y  : year (eg. 2015)
 #   %m  : month (eg. 09)

--- a/katal/katal.py
+++ b/katal/katal.py
@@ -784,8 +784,6 @@ class Filter:
                             conditions
                 o self.name : the name of the Filter, from the name parameter.
     """
-
-    #///////////////////////////////////////////////////////////////////////////
     def __init__(self, config=None, name=''):
         self.conditions = {}
         self.name = name
@@ -1078,8 +1076,8 @@ class Filter:
                               if not test(file_name)]
 
         if list_tests_failled:
-            LOGGER.info('  o The following tests failed for filter "%s" and file "%s": '
-                        '%s', self.name, file_name, list_tests_failled)
+            LOGGER.debug('  o The following tests failed for filter "%s" and file "%s": '
+                         '%s', self.name, file_name, list_tests_failled)
             return False
         else:
             return True
@@ -1113,7 +1111,11 @@ class Filter:
 
             RETURNED VALUE : self.intersection(filter2)
         """
-        return lambda file_set: self(file_set) & filter2(file_set)
+        filter = self
+        class And(Filter):
+            def __call__(self, file_set):
+                return filter(file_set) & filter2(file_set)
+        return And()
 
     #///////////////////////////////////////////////////////////////////////////
     def __or__(self, filter2):
@@ -1129,7 +1131,11 @@ class Filter:
 
             RETURNED VALUE : self.union(filter2)
         """
-        return lambda file_set: self(file_set) | filter2(file_set)
+        filter = self
+        class Or(Filter):
+            def __call__(self, file_set):
+                return filter(file_set) | filter2(file_set)
+        return Or()
 
     #///////////////////////////////////////////////////////////////////////////
     def __xor__(self, filter2):
@@ -1145,7 +1151,11 @@ class Filter:
 
             RETURNED VALUE : self.symmetric_difference(filter2)
         """
-        return lambda file_set: self(file_set) ^ filter2(file_set)
+        filter = self
+        class Xor(Filter):
+            def __call__(self, file_set):
+                return filter(file_set) ^ filter2(file_set)
+        return Xor()
 
     #///////////////////////////////////////////////////////////////////////////
     def __invert__(self):
@@ -1160,7 +1170,11 @@ class Filter:
 
             RETURNED VALUE : file_set.differrence(self)
         """
-        return lambda file_set: file_set - self(file_set)
+        filter = self
+        class Not(Filter):
+            def __call__(self, file_set):
+                return file_set - filter(file_set)
+        return Not()
 
 
 # The order matter !

--- a/katal/katal.py
+++ b/katal/katal.py
@@ -305,6 +305,14 @@ class Config(configparser.ConfigParser):
         self.read_parameters_from_cfgfile()
 
     def arguments_to_dict(self):
+        """
+        self.arguments_to_dict() -> dict
+
+        ________________________________________________________________________
+
+        Convert the argument to a dict ready to be parsed by self.read_dict to
+        update config.
+        """
         return {
             'display': {
                 'verbosity': self.verbosity,
@@ -350,43 +358,53 @@ class Config(configparser.ConfigParser):
             parser.error("--copyto can only be used in combination with --findtag .")
 
 #///////////////////////////////////////////////////////////////////////////////
-    def default_config(self):
+    @staticmethod
+    def default_config():
         """self.default_config() -> dict of default config"""
         return {
-        'source': {
-            'path': '.',
-            'eval': '*',
-            'strict comparison': False,
-            'read hidden files': False,
-        },
-        'target': {
-            'mode': 'copy',
-            'name of the target file': '%i.%e',
-        },
-        'log file': {
-            'use log file': True,
-            'name': 'katal.log',
-            'maximal size': 1e8,
-        },
-        'display': {
-            'target filename.max length on console': 30,
-            'source filename.max length on console': 40,
-            'hashid.max length on console': 20,
-            'tag.max length on console': 10,
-            'verbosity': 'debug',
-        },
-        'actions': {
-            'add': False,
-            'cleandbrm': False
-        },
-        'tags': {}
-    }
+            'source': {
+                'path': '.',
+                'eval': '*',
+                'strict comparison': False,
+                'read hidden files': False,
+            },
+            'target': {
+                'mode': 'copy',
+                'name of the target file': '%i.%e',
+            },
+            'log file': {
+                'use log file': True,
+                'name': 'katal.log',
+                'maximal size': 1e8,
+            },
+            'display': {
+                'target filename.max length on console': 30,
+                'source filename.max length on console': 40,
+                'hashid.max length on console': 20,
+                'tag.max length on console': 10,
+                'verbosity': 'debug',
+            },
+            'actions': {
+                'add': False,
+                'cleandbrm': False
+            },
+            'tags': {}
+        }
 
     @property
     def normtargetpath(self):
+        """self.normtargetpath -> normpath(self.targetpath)"""
         return normpath(self.targetpath)
 
     def read_all_config_files(self, cfg_file=None):
+        """
+        self.read_all_config_files()
+
+        ________________________________________________________________________
+
+        Read all default config files from self.possible_paths_to_cfg(), read
+        the config file passed as an argument, and cfg_file if provided.
+        """
         # Order matter
         config_files = self.possible_paths_to_cfg()
 
@@ -394,12 +412,12 @@ class Config(configparser.ConfigParser):
 
         if self.configfile:
             try:
-                with open(self.configfile) as f:
-                    self.read_file(f)
+                with open(self.configfile) as file:
+                    self.read_file(file)
                     cfg_files.append(self.configfile)
             except FileNotFoundError:
                 print('  ! The config file "%s" (path : "%s") '
-                    " doesn't exist. " % self.configfile, normpath(self.configfile))
+                      " doesn't exist. " % self.configfile, normpath(self.configfile))
                 raise ConfigError
 
         if cfg_file:
@@ -429,29 +447,29 @@ class Config(configparser.ConfigParser):
         parser = \
         argparse.ArgumentParser(description="{0} v. {1}".format(__projectname__, __version__),
                                 epilog="{0} v. {1} ({2}), "
-                                        "a project by {3} "
-                                        "({4})".format(__projectname__,
-                                                        __version__,
-                                                        __license__,
-                                                        __author__,
-                                                        __email__),
+                                       "a project by {3} "
+                                       "({4})".format(__projectname__,
+                                                      __version__,
+                                                      __license__,
+                                                      __author__,
+                                                      __email__),
                                 formatter_class=argparse.ArgumentDefaultsHelpFormatter)
 
         exclusive_group = parser.add_mutually_exclusive_group()
 
         exclusive_group.add_argument('--add',
-                            action="store_true",
-                            help="# Select files according to what is described "
-                                "in the configuration file "
-                                "then add them to the target directory. "
-                                "This option can't be used with the --select one."
-                                "If you want more informations about the process, please "
-                                "use this option in combination with --infos .")
+                                     action="store_true",
+                                     help="# Select files according to what is described "
+                                     "in the configuration file "
+                                     "then add them to the target directory. "
+                                     "This option can't be used with the --select one."
+                                     "If you want more informations about the process, please "
+                                     "use this option in combination with --infos .")
 
         parser.add_argument('--addtag',
                             type=str,
                             help="# Add a tag to some file(s) in combination "
-                                "with the --to option. ")
+                                 "with the --to option. ")
 
         parser.add_argument('-cfg', '--configfile',
                             type=str,
@@ -464,26 +482,26 @@ class Config(configparser.ConfigParser):
         parser.add_argument('--copyto',
                             type=str,
                             help="# To be used with the --findtag parameter. Copy the found files "
-                                "into an export directory.")
+                                 "into an export directory.")
 
         parser.add_argument('-dlcfg', '--downloaddefaultcfg',
                             choices=("local", "home",),
                             help="# Download the default config file and overwrite the file having "
-                                "the same name. This is done before the script reads the parameters "
-                                "in the config file. Use 'local' to download in the current "
-                                "directory, 'home' to download in the user's HOME directory.")
+                                 "the same name. This is done before the script reads the parameters "
+                                 "in the config file. Use 'local' to download in the current "
+                                 "directory, 'home' to download in the user's HOME directory.")
 
         parser.add_argument('--findtag',
                             type=str,
                             help="# Find the files in the target directory with the given tag. "
-                                "The tag is a simple string, not a regex.")
+                                 "The tag is a simple string, not a regex.")
 
         parser.add_argument('--infos',
                             action="store_true",
                             help="# Display informations about the source directory "
-                                "given in the configuration file. Help the --select/--add "
-                                "options to display more informations about the process : in "
-                                "this case, the --infos will be executed before --select/--add")
+                                 "given in the configuration file. Help the --select/--add "
+                                 "options to display more informations about the process : in "
+                                 "this case, the --infos will be executed before --select/--add")
 
         parser.add_argument('-n', '--new',
                             type=str,
@@ -492,18 +510,18 @@ class Config(configparser.ConfigParser):
         parser.add_argument('--off',
                             action="store_true",
                             help="# Don't write anything into the target directory or into "
-                                "the database, except into the current log file. "
-                                "Use this option to simulate an operation : you get the messages "
-                                "but no file is modified on disk, no directory is created.")
+                                 "the database, except into the current log file. "
+                                 "Use this option to simulate an operation : you get the messages "
+                                 "but no file is modified on disk, no directory is created.")
 
         parser.add_argument('--rebase',
                             type=str,
                             help="# Copy the current target directory into a new one : you "
-                                "rename the files in the target directory and in the database. "
-                                "First, use the --new option to create a new target directory, "
-                                "modify the .ini file of the new target directory "
-                                "(modify [target]name of the target files), "
-                                "then use --rebase with the name of the new target directory")
+                                 "rename the files in the target directory and in the database. "
+                                 "First, use the --new option to create a new target directory, "
+                                 "modify the .ini file of the new target directory "
+                                 "(modify [target]name of the target files), "
+                                 "then use --rebase with the name of the new target directory")
 
         parser.add_argument('--reset',
                             action="store_true",
@@ -516,25 +534,25 @@ class Config(configparser.ConfigParser):
         parser.add_argument('--rmtags',
                             action="store_true",
                             help="# Remove all the tags of some file(s) in combination "
-                                "with the --to option. ")
+                                 "with the --to option. ")
 
         exclusive_group.add_argument('-s', '--select',
-                            action="store_true",
-                            help="# Select files according to what is described "
-                                "in the configuration file "
-                                "without adding them to the target directory. "
-                                "This option can't be used with the --add one."
-                                "If you want more informations about the process, please "
-                                "use this option in combination with --infos .")
+                                     action="store_true",
+                                     help="# Select files according to what is described "
+                                     "in the configuration file "
+                                     "without adding them to the target directory. "
+                                     "This option can't be used with the --add one."
+                                     "If you want more informations about the process, please "
+                                     "use this option in combination with --infos .")
 
         parser.add_argument('--settagsstr',
                             type=str,
                             help="# Give the tag to some file(s) in combination "
-                                "with the --to option. "
-                                "Overwrite the ancient tag string. "
-                                "If you want to empty the tags' string, please use a space, "
-                                "not an empty string : otherwise the parameter given "
-                                "to the script wouldn't be taken in account by the shell")
+                                 "with the --to option. "
+                                 "Overwrite the ancient tag string. "
+                                 "If you want to empty the tags' string, please use a space, "
+                                 "not an empty string : otherwise the parameter given "
+                                 "to the script wouldn't be taken in account by the shell")
 
         parser.add_argument('-si', '--sourceinfos',
                             action="store_true",
@@ -543,14 +561,14 @@ class Config(configparser.ConfigParser):
         parser.add_argument('--strictcmp',
                             action="store_true",
                             help="# To be used with --add or --select. Force a bit-to-bit comparision"
-                                "between files whose hashid-s is equal.")
+                                 "between files whose hashid-s is equal.")
 
         parser.add_argument('--targetpath',
                             type=str,
                             default=".",
                             help="# Target path, usually '.' . If you set path to . (=dot character)"
-                                ", it means that the source path is the current directory"
-                                " (=the directory where the script katal.py has been launched)")
+                                 ", it means that the source path is the current directory"
+                                 " (=the directory where the script katal.py has been launched)")
 
         parser.add_argument('-ti', '--targetinfos',
                             action="store_true",
@@ -559,9 +577,9 @@ class Config(configparser.ConfigParser):
         parser.add_argument('-tk', '--targetkill',
                             type=str,
                             help="# Kill (=move to the trash directory) one file from "
-                                "the target directory."
-                                "DO NOT GIVE A PATH, just the file's name, "
-                                "without the path to the target directory")
+                                 "the target directory."
+                                 "DO NOT GIVE A PATH, just the file's name, "
+                                 "without the path to the target directory")
 
         parser.add_argument('--to',
                             type=str,
@@ -572,18 +590,16 @@ class Config(configparser.ConfigParser):
         parser.add_argument('--usentfsprefix',
                             action="store_true",
                             help="# Force the script to prefix filenames by a special string "
-                                "required by the NTFS for long filenames, namely \\\\?\\")
+                                 "required by the NTFS for long filenames, namely \\\\?\\")
 
         parser.add_argument('--verbosity',
                             choices=("none", "normal", "high"),
                             default='normal',
                             help="# Console verbosity : "
-                                "'none'=no output to the console, no question asked on the console; "
-                                "'normal'=messages to the console "
-                                "and questions asked on the console; "
-                                "'high'=display discarded files. A question may be asked only by "
-                                "using the following arguments : "
-                                "--new, --rebase, --reset and --select")
+                            "'none'=no output to the console, no question asked on the console; "
+                            "'normal'=messages to the console and questions asked on the console; "
+                            "'high'=display discarded files. A question may be asked only by "
+                            "using the following arguments : --new, --rebase, --reset and --select")
 
         parser.add_argument('--version',
                             action='version',
@@ -593,8 +609,8 @@ class Config(configparser.ConfigParser):
         parser.add_argument('--whatabout',
                             type=str,
                             help="# Say if the file[the files in a directory] already in the "
-                                "given as a parameter is in the target directory "
-                                "notwithstanding its name.")
+                                 "given as a parameter is in the target directory "
+                                 "notwithstanding its name.")
 
         parser.parse_args(args=args, namespace=self)
 
@@ -682,7 +698,7 @@ class Config(configparser.ConfigParser):
             print("  ! An error occurred while reading config files.")
             print('  ! Your configuration file lacks a specific value : "%s".' % exception)
             print("  ... you should download a new default config file : "
-                        "see -dlcfg/--downloaddefaultcfg option")
+                  "see -dlcfg/--downloaddefaultcfg option")
             raise ConfigError
         except configparser.Error as exception:
             print("  ! An error occurred while reading the config files.")
@@ -835,7 +851,7 @@ class Filter:
 
         PARAMETERS
                 o regex : (str) the string from config file corresponding
-                                to the condition on date (eg. .*\.jpg).
+                                to the condition on date (eg. .*\\.jpg).
 
         RETURNED VALUE
                 o function(file_name) : function which test if the file match the regex
@@ -1204,9 +1220,9 @@ class SelectElement(SelectTuple):
 
         # to don't have to compile the regex every time
         date_regex = getattr(cls, 'date_regex',
-                            re.compile(r"%d\((.*?)\)")) # Match '%d(format)'
+                             re.compile(r"%d\((.*?)\)")) # Match '%d(format)'
         ddate_regex = getattr(cls, 'ddate_regex',
-                            re.compile(r"%dd\((.*?)\)")) # Match '%d(format)'
+                              re.compile(r"%dd\((.*?)\)")) # Match '%d(format)'
         cls.date_regex = date_regex
         cls.ddate_regex = ddate_regex
 
@@ -1260,6 +1276,7 @@ class SelectElement(SelectTuple):
 
     @property
     def date(self):
+        """self.date -> last modification date formated with CST__DTIME_FORMAT"""
         return datetime.fromtimestamp(self.time).strftime(CST__DTIME_FORMAT)
     def __eq__(self, other):
         """
@@ -1361,12 +1378,12 @@ def action__add():
             else:
                 raise KatalError('Mode {} not valid'.format(mode))
 
-    except Exception as e:
+    except Exception as exception:
         # An error occurred, we cancel the transaction
         db_connection.rollback()
         # remove all previously copied files
         clean(element.targetname for element in SELECT)
-        if isinstance(e, sqlite3.IntegrityError):
+        if isinstance(exception, sqlite3.IntegrityError):
             LOGGER.exception("!!! An error occurred while writing the database : ")
             raise KatalError("An error occurred while writing the database.")
 
@@ -1584,7 +1601,7 @@ def action__new(targetname):
         no PARAMETER, no RETURNED VALUE
     """
     LOGGER.info("  = about to create a new target directory "
-                   "named \"%s\" (path : \"%s\")", targetname, normpath(targetname))
+                "named \"%s\" (path : \"%s\")", targetname, normpath(targetname))
 
     targetname = normpath(targetname)
 
@@ -1815,7 +1832,8 @@ def action__reset():
         if answer not in ("y", "yes"):
             return
 
-    files_to_be_removed = [element.targetname for element in read_target_db2()]  # a list of fullname
+    # a list of fullname
+    files_to_be_removed = [element.targetname for element in read_target_db2()]
 
     db_connection = sqlite3.connect(get_database_fullname())
     db_cursor = db_connection.cursor()
@@ -1852,7 +1870,7 @@ def action__rmnotags():
     LOGGER.info("  = removing all files with no tags (=moving them to the trash).")
 
     files_to_be_removed = [element.targetname for element in read_target_db2()
-                            if not element.targettags]    # list of name
+                           if not element.targettags]    # list of name
 
     target_trash = [os.path.join(normpath(ARGS.targetpath), CST__KATALSYS_SUBDIR,
                                  CST__TRASH_SUBSUBDIR, os.path.basename(name))
@@ -1869,7 +1887,7 @@ def action__rmnotags():
                 LOGGER.info("   o removing %s from the database and from the target path", name)
                 if not ARGS.off:
                     # let's remove the file from the target directory :
-                    copy(name,target)
+                    copy(name, target)
 
                     # let's remove the file from the database :
                     db_cursor.execute("DELETE FROM dbfiles WHERE targetname=?", (name,))
@@ -2202,7 +2220,7 @@ def copy(src, dst):
     """
     try:
         shutil.copy2(src, dst)
-    except FileNotFoundError as e:
+    except FileNotFoundError:
         if not os.path.exists(os.path.dirname(dst)):
             os.makedirs(os.path.dirname(dst))
             shutil.copy2(src, dst)
@@ -2263,14 +2281,14 @@ def create_subdirs_in_target_path(targetpath=None):
     # (str)name for the message, (str)full path :
     for name, fullpath in \
             (("target", targetpath),
-            ("system", os.path.join(targetpath,
-                                    CST__KATALSYS_SUBDIR)),
-            ("trash", os.path.join(targetpath,
-                                   CST__KATALSYS_SUBDIR, CST__TRASH_SUBSUBDIR)),
-            ("log", os.path.join(targetpath,
-                                 CST__KATALSYS_SUBDIR, CST__LOG_SUBSUBDIR)),
-            ("tasks", os.path.join(targetpath,
-                                   CST__KATALSYS_SUBDIR, CST__TASKS_SUBSUBDIR))):
+             ("system", os.path.join(targetpath,
+                                     CST__KATALSYS_SUBDIR)),
+             ("trash", os.path.join(targetpath,
+                                    CST__KATALSYS_SUBDIR, CST__TRASH_SUBSUBDIR)),
+             ("log", os.path.join(targetpath,
+                                  CST__KATALSYS_SUBDIR, CST__LOG_SUBSUBDIR)),
+             ("tasks", os.path.join(targetpath,
+                                    CST__KATALSYS_SUBDIR, CST__TASKS_SUBSUBDIR))):
         if not os.path.exists(fullpath) and not ARGS.off:
             LOGGER.info('  * Since the %s path "%s" '
                         "doesn't exist, let's create it.", name, fullpath)
@@ -2672,7 +2690,7 @@ def main(args=None):
         o  sys.exit(-2) is called if a KatalError exception is raised
         o  sys.exit(-3) is called if another exception is raised
     """
-    global ARGS, CONFIG
+    global ARGS
 
     timestamp_start = datetime.now()
 

--- a/tests/test_pytest.py
+++ b/tests/test_pytest.py
@@ -220,6 +220,19 @@ def test_select6(src_dir, target_dir, conf):
     assert {e.srcname for e in katal.SELECT} == set()
     assert {e.targetname for e in katal.SELECT} == set()
 
+def test_select7(src_dir, target_dir, conf):
+    conf.targetpath = str(target_dir)
+    conf.read_dict({'source': {'eval': 'filter1 & ~(filter2 | filter3)', 'path': str(src_dir)},
+                    'source.filter1': {'iname': '.*\.1'},
+                    'source.filter2': {'iname': '.*\.2'},
+                    'source.filter3': {'iname': '.*\.3'},
+                    'target': {'name of the target files': '%n', 'tags': ''}})
+
+    katal.read_filters()
+    katal.fill_select()
+
+    assert {e.srcname for e in katal.SELECT} == {src_dir.join(f) for f in ('a.1',)}
+
 def test_subdir1(src_dir, target_dir, conf):
     conf.targetpath = str(target_dir)
     conf.read_dict({'source': {'eval': 'filter1', 'path': str(src_dir)},

--- a/tests/test_pytest.py
+++ b/tests/test_pytest.py
@@ -26,19 +26,56 @@
 # pylint: disable=E1101
 
 from unittest.mock import MagicMock
+import os
+from datetime import datetime
+import random
 
 import pytest
 
 from katal import katal
 
-@pytest.fixture(autouse=True)
-def tmp_target_dir(tmpdir):
+def populate(path, name, time=None, size=0):
+    p = path.join(name)
+    # Random, else every file has the same hashid
+    with p.open('w') as f:
+        f.seek(size)
+        f.write(str(random.random()))
+
+    if time:
+        time = datetime.strptime(time, '%Y-%m-%d %H:%M').timestamp()
+        os.utime(str(p), (time, time))
+
+@pytest.fixture(scope='session', autouse=True)
+def tmp_target_dir(tmpdir_factory):
     katal.ARGS = MagicMock()
+    tmpdir = tmpdir_factory.mktemp('katal')
     katal.ARGS.targetpath = tmpdir
+
+    populate(tmpdir, 'a.1', size=1024**2)
+    populate(tmpdir, 'b.2', time='2016-01-24 12:34')
+    populate(tmpdir, 'c.3', time='2016-01-24 13:02')
+    populate(tmpdir, 'd.4')
+
     return tmpdir
 
+@pytest.fixture(autouse=True)
+def conf():
+    args = '--verbosity none'.split()
 
-def test_initialization(tmp_target_dir):
+    conf = katal.Config()
+    katal.CONFIG = conf
+    katal.ARGS = conf
+    katal.CFG_PARAMETERS = conf
+    conf.read_command_line_arguments(args)
+    conf.read_dict(conf.default_config())
+    conf.read_dict(conf.arguments_to_dict())
+
+    return conf
+
+def pwd_path(filename):
+    return os.path.join(os.path.abspath(os.path.curdir), filename)
+
+def initialization(tmp_target_dir):
     args = '-cfg tests/cfgfile1.ini'.split()
 
     try:
@@ -54,4 +91,92 @@ def test_initialization(tmp_target_dir):
         assert path.join(p).ensure(dir=True)
 
     assert path.join(katal.get_logfile_fullname()).ensure()
+
+def test_select1(tmp_target_dir, conf):
+    conf.read_dict({'source': {'eval': 'filter1', 'path': str(tmp_target_dir)},
+                    'source.filter1': {'name': '.*'},
+                    'target': {'name of the target files': '%fs.%e', 'tags': ''}})
+
+    katal.read_filters()
+    katal.fill_select()
+
+    assert {e.srcname for e in katal.SELECT} == {tmp_target_dir.join(f) for f in ('a.1', 'b.2', 'c.3', 'd.4')}
+    assert {e.targetname for e in katal.SELECT} == {pwd_path(f) for f in ('as.1', 'bs.2', 'cs.3', 'ds.4')}
+
+def test_select2(tmp_target_dir, conf):
+    conf.read_dict({'source': {'eval': 'filter1', 'path': str(tmp_target_dir)},
+                    'source.filter1': {'name': '.*2$'},
+                    'target': {'name of the target files': '%ne', 'tags': ''}})
+
+    katal.read_filters()
+    katal.fill_select()
+
+    assert {e.srcname for e in katal.SELECT} == {tmp_target_dir.join(f) for f in ('b.2',)}
+    assert {e.targetname for e in katal.SELECT} == {pwd_path(f) for f in ('b.2e',)}
+
+def test_select3(tmp_target_dir, conf):
+    conf.read_dict({'source': {'eval': 'filter1', 'path': str(tmp_target_dir)},
+                    'source.filter1': {'size': '<=1kB'},
+                    'target': {'name of the target files': '%n', 'tags': ''}})
+
+    katal.read_filters()
+    katal.fill_select()
+
+    assert {e.srcname for e in katal.SELECT} == {tmp_target_dir.join(f) for f in ('b.2', 'c.3', 'd.4')}
+    assert {e.targetname for e in katal.SELECT} == {pwd_path(f) for f in ('b.2', 'c.3', 'd.4')}
+
+def test_select3(tmp_target_dir, conf):
+    conf.read_dict({'source': {'eval': 'filter1', 'path': str(tmp_target_dir)},
+                    'source.filter1': {'size': '<=1kB', 'date': '>=2016-01-24 13:00'},
+                    'target': {'name of the target files': '%n', 'tags': ''}})
+
+    katal.read_filters()
+    katal.fill_select()
+
+    assert {e.srcname for e in katal.SELECT} == {tmp_target_dir.join(f) for f in ('c.3', 'd.4')}
+    assert {e.targetname for e in katal.SELECT} == {pwd_path(f) for f in ('c.3', 'd.4')}
+
+def test_select4(tmp_target_dir, conf):
+    conf.read_dict({'source': {'eval': 'filter1', 'path': str(tmp_target_dir)},
+                    'source.filter1': {'size': '<=1kB', 'date': '>=2016-02'},
+                    'target': {'name of the target files': '%n', 'tags': ''}})
+
+    katal.read_filters()
+    katal.fill_select()
+
+    assert {e.srcname for e in katal.SELECT} == {tmp_target_dir.join(f) for f in ('d.4',)}
+    assert {e.targetname for e in katal.SELECT} == {pwd_path(f) for f in ('d.4',)}
+
+def test_select5(tmp_target_dir, conf):
+    conf.read_dict({'source': {'eval': 'filter1', 'path': str(tmp_target_dir)},
+                    'source.filter1': {'date': '<=2016-02'},
+                    'target': {'name of the target files': '%Y-%d(%m)-%f', 'tags': ''}})
+
+    katal.read_filters()
+    katal.fill_select()
+
+    assert {e.srcname for e in katal.SELECT} == {tmp_target_dir.join(f) for f in ('b.2', 'c.3')}
+    assert {e.targetname for e in katal.SELECT} == {pwd_path(f) for f in ('2016-01-b', '2016-01-c')}
+
+def test_select6(tmp_target_dir, conf):
+    conf.read_dict({'source': {'eval': 'filter1', 'path': str(tmp_target_dir)},
+                    'source.filter1': {'external program': 'false'},
+                    'target': {'name of the target files': '%n', 'tags': ''}})
+
+    katal.read_filters()
+    katal.fill_select()
+
+    assert {e.srcname for e in katal.SELECT} == set()
+    assert {e.targetname for e in katal.SELECT} == set()
+
+def test_subdir1(tmp_target_dir, conf):
+    conf.read_dict({'source': {'eval': 'filter1', 'path': str(tmp_target_dir)},
+                    'source.filter1': {},
+                    'target': {'name of the target files': '%Y/%n', 'tags': ''}})
+
+    katal.read_filters()
+    katal.fill_select()
+
+    assert {e.srcname for e in katal.SELECT} == {tmp_target_dir.join(f) for f in ('a.1', 'b.2', 'c.3', 'd.4')}
+    assert {e.targetname for e in katal.SELECT} == {pwd_path(f) for f in ('2016/a.1', '2016/b.2', '2016/c.3', '2016/d.4')}
 

--- a/tests/test_pytest.py
+++ b/tests/test_pytest.py
@@ -118,9 +118,6 @@ def populate(path, name, time=None, size=0):
         time = datetime.strptime(time, '%Y-%m-%d %H:%M').timestamp()
         os.utime(str(p), (time, time))
 
-def pwd_path(filename):
-    return os.path.join(os.path.abspath(os.path.curdir), filename)
-
 
 def initialization(src_dir):
     args = '-cfg tests/cfgfile1.ini'.split()
@@ -139,29 +136,32 @@ def initialization(src_dir):
 
     assert path.join(katal.get_logfile_fullname()).ensure()
 
-def test_select1(src_dir, conf):
+def test_select1(src_dir, target_dir, conf):
     conf.read_dict({'source': {'eval': 'filter1', 'path': str(src_dir)},
                     'source.filter1': {'name': '.*'},
                     'target': {'name of the target files': '%fs.%e', 'tags': ''}})
+    conf.targetpath = str(target_dir)
 
     katal.read_filters()
     katal.fill_select()
 
     assert {e.srcname for e in katal.SELECT} == {src_dir.join(f) for f in ('a.1', 'b.2', 'c.3', 'd.4')}
-    assert {e.targetname for e in katal.SELECT} == {pwd_path(f) for f in ('as.1', 'bs.2', 'cs.3', 'ds.4')}
+    assert {e.targetname for e in katal.SELECT} == {target_dir.join(f) for f in ('as.1', 'bs.2', 'cs.3', 'ds.4')}
 
-def test_select2(src_dir, conf):
+def test_select2(src_dir, target_dir, conf):
     conf.read_dict({'source': {'eval': 'filter1', 'path': str(src_dir)},
                     'source.filter1': {'name': '.*2$'},
                     'target': {'name of the target files': '%ne', 'tags': ''}})
+    conf.targetpath = str(target_dir)
 
     katal.read_filters()
     katal.fill_select()
 
     assert {e.srcname for e in katal.SELECT} == {src_dir.join(f) for f in ('b.2',)}
-    assert {e.targetname for e in katal.SELECT} == {pwd_path(f) for f in ('b.2e',)}
+    assert {e.targetname for e in katal.SELECT} == {target_dir.join(f) for f in ('b.2e',)}
 
-def test_select3(src_dir, conf):
+def test_select3(src_dir, target_dir, conf):
+    conf.targetpath = str(target_dir)
     conf.read_dict({'source': {'eval': 'filter1', 'path': str(src_dir)},
                     'source.filter1': {'size': '<=1kB'},
                     'target': {'name of the target files': '%n', 'tags': ''}})
@@ -170,9 +170,10 @@ def test_select3(src_dir, conf):
     katal.fill_select()
 
     assert {e.srcname for e in katal.SELECT} == {src_dir.join(f) for f in ('b.2', 'c.3', 'd.4')}
-    assert {e.targetname for e in katal.SELECT} == {pwd_path(f) for f in ('b.2', 'c.3', 'd.4')}
+    assert {e.targetname for e in katal.SELECT} == {target_dir.join(f) for f in ('b.2', 'c.3', 'd.4')}
 
-def test_select3(src_dir, conf):
+def test_select3(src_dir, target_dir, conf):
+    conf.targetpath = str(target_dir)
     conf.read_dict({'source': {'eval': 'filter1', 'path': str(src_dir)},
                     'source.filter1': {'size': '<=1kB', 'date': '>=2016-01-24 13:00'},
                     'target': {'name of the target files': '%n', 'tags': ''}})
@@ -181,9 +182,10 @@ def test_select3(src_dir, conf):
     katal.fill_select()
 
     assert {e.srcname for e in katal.SELECT} == {src_dir.join(f) for f in ('c.3', 'd.4')}
-    assert {e.targetname for e in katal.SELECT} == {pwd_path(f) for f in ('c.3', 'd.4')}
+    assert {e.targetname for e in katal.SELECT} == {target_dir.join(f) for f in ('c.3', 'd.4')}
 
-def test_select4(src_dir, conf):
+def test_select4(src_dir, target_dir, conf):
+    conf.targetpath = str(target_dir)
     conf.read_dict({'source': {'eval': 'filter1', 'path': str(src_dir)},
                     'source.filter1': {'size': '<=1kB', 'date': '>=2016-02'},
                     'target': {'name of the target files': '%n', 'tags': ''}})
@@ -192,9 +194,10 @@ def test_select4(src_dir, conf):
     katal.fill_select()
 
     assert {e.srcname for e in katal.SELECT} == {src_dir.join(f) for f in ('d.4',)}
-    assert {e.targetname for e in katal.SELECT} == {pwd_path(f) for f in ('d.4',)}
+    assert {e.targetname for e in katal.SELECT} == {target_dir.join(f) for f in ('d.4',)}
 
-def test_select5(src_dir, conf):
+def test_select5(src_dir, target_dir, conf):
+    conf.targetpath = str(target_dir)
     conf.read_dict({'source': {'eval': 'filter1', 'path': str(src_dir)},
                     'source.filter1': {'date': '<=2016-02'},
                     'target': {'name of the target files': '%Y-%d(%m)-%f', 'tags': ''}})
@@ -203,9 +206,10 @@ def test_select5(src_dir, conf):
     katal.fill_select()
 
     assert {e.srcname for e in katal.SELECT} == {src_dir.join(f) for f in ('b.2', 'c.3')}
-    assert {e.targetname for e in katal.SELECT} == {pwd_path(f) for f in ('2016-01-b', '2016-01-c')}
+    assert {e.targetname for e in katal.SELECT} == {target_dir.join(f) for f in ('2016-01-b', '2016-01-c')}
 
-def test_select6(src_dir, conf):
+def test_select6(src_dir, target_dir, conf):
+    conf.targetpath = str(target_dir)
     conf.read_dict({'source': {'eval': 'filter1', 'path': str(src_dir)},
                     'source.filter1': {'external program': 'false'},
                     'target': {'name of the target files': '%n', 'tags': ''}})
@@ -216,7 +220,8 @@ def test_select6(src_dir, conf):
     assert {e.srcname for e in katal.SELECT} == set()
     assert {e.targetname for e in katal.SELECT} == set()
 
-def test_subdir1(src_dir, conf):
+def test_subdir1(src_dir, target_dir, conf):
+    conf.targetpath = str(target_dir)
     conf.read_dict({'source': {'eval': 'filter1', 'path': str(src_dir)},
                     'source.filter1': {},
                     'target': {'name of the target files': '%Y/%n', 'tags': ''}})
@@ -225,7 +230,7 @@ def test_subdir1(src_dir, conf):
     katal.fill_select()
 
     assert {e.srcname for e in katal.SELECT} == {src_dir.join(f) for f in ('a.1', 'b.2', 'c.3', 'd.4')}
-    assert {e.targetname for e in katal.SELECT} == {pwd_path(f) for f in ('2016/a.1', '2016/b.2', '2016/c.3', '2016/d.4')}
+    assert {e.targetname for e in katal.SELECT} == {target_dir.join(f) for f in ('2016/a.1', '2016/b.2', '2016/c.3', '2016/d.4')}
 
 def test_copy(src_dir, target_dir, conf):
     conf.read_dict({'source': {'eval': 'filter1', 'path': str(src_dir)},

--- a/tests/test_pytest.py
+++ b/tests/test_pytest.py
@@ -28,11 +28,57 @@
 from unittest.mock import MagicMock
 import os
 from datetime import datetime
+import filecmp
 import random
+import sqlite3
 
 import pytest
 
 from katal import katal
+
+@pytest.fixture
+def working_dir(tmpdir):
+    """
+    Like src_dir, but scope is not session.
+    Useful when files are moved or deleted.
+    """
+    src_dir = tmpdir.mkdir('source')
+    target_dir = tmpdir.mkdir('target')
+
+    populate(src_dir, 'a.1', size=1024**2)
+    populate(src_dir, 'b.2', time='2016-01-24 12:34')
+    populate(src_dir, 'c.3', time='2016-01-24 13:02')
+    populate(src_dir, 'd.4')
+
+    return src_dir, target_dir
+
+@pytest.fixture(autouse=True)
+def conf():
+    args = '--verbosity none'.split()
+
+    conf = katal.Config()
+    katal.CONFIG = katal.ARGS = katal.CFG_PARAMETERS = conf
+    conf.read_command_line_arguments(args)
+    conf.read_dict(conf.default_config())
+    conf.read_dict(conf.arguments_to_dict())
+
+    assert conf is katal.CONFIG
+    assert conf is katal.ARGS
+
+    return conf
+
+def read_db(config):
+    katal.ARGS = katal.CONF = katal.CFG_PARAMETERS = config
+    name = katal.get_database_fullname()
+
+    con = sqlite3.Connection(name)
+    con.row_factory = sqlite3.Row
+    c = con.cursor()
+    c.execute('SELECT * FROM dbfiles')
+    l = c.fetchall()
+    con.close()
+
+    return l
 
 def populate(path, name, time=None, size=0):
     p = path.join(name)
@@ -45,37 +91,10 @@ def populate(path, name, time=None, size=0):
         time = datetime.strptime(time, '%Y-%m-%d %H:%M').timestamp()
         os.utime(str(p), (time, time))
 
-@pytest.fixture(scope='session', autouse=True)
-def tmp_target_dir(tmpdir_factory):
-    katal.ARGS = MagicMock()
-    tmpdir = tmpdir_factory.mktemp('katal')
-    katal.ARGS.targetpath = tmpdir
-
-    populate(tmpdir, 'a.1', size=1024**2)
-    populate(tmpdir, 'b.2', time='2016-01-24 12:34')
-    populate(tmpdir, 'c.3', time='2016-01-24 13:02')
-    populate(tmpdir, 'd.4')
-
-    return tmpdir
-
-@pytest.fixture(autouse=True)
-def conf():
-    args = '--verbosity none'.split()
-
-    conf = katal.Config()
-    katal.CONFIG = conf
-    katal.ARGS = conf
-    katal.CFG_PARAMETERS = conf
-    conf.read_command_line_arguments(args)
-    conf.read_dict(conf.default_config())
-    conf.read_dict(conf.arguments_to_dict())
-
-    return conf
-
 def pwd_path(filename):
     return os.path.join(os.path.abspath(os.path.curdir), filename)
 
-def initialization(tmp_target_dir):
+def initialization(src_dir):
     args = '-cfg tests/cfgfile1.ini'.split()
 
     try:
@@ -84,7 +103,7 @@ def initialization(tmp_target_dir):
         assert not system_exit.code
 
 
-    path = tmp_target_dir.join(katal.CST__KATALSYS_SUBDIR)
+    path = src_dir.join(katal.CST__KATALSYS_SUBDIR)
     for p in ['', katal.CST__LOG_SUBSUBDIR, katal.CST__TRASH_SUBSUBDIR,
               katal.CST__TASKS_SUBSUBDIR]:
 
@@ -92,74 +111,81 @@ def initialization(tmp_target_dir):
 
     assert path.join(katal.get_logfile_fullname()).ensure()
 
-def test_select1(tmp_target_dir, conf):
-    conf.read_dict({'source': {'eval': 'filter1', 'path': str(tmp_target_dir)},
+def test_select1(working_dir, conf):
+    src_dir, target_dir = working_dir
+    conf.read_dict({'source': {'eval': 'filter1', 'path': str(src_dir)},
                     'source.filter1': {'name': '.*'},
                     'target': {'name of the target files': '%fs.%e', 'tags': ''}})
 
     katal.read_filters()
     katal.fill_select()
 
-    assert {e.srcname for e in katal.SELECT} == {tmp_target_dir.join(f) for f in ('a.1', 'b.2', 'c.3', 'd.4')}
+    assert {e.srcname for e in katal.SELECT} == {src_dir.join(f) for f in ('a.1', 'b.2', 'c.3', 'd.4')}
     assert {e.targetname for e in katal.SELECT} == {pwd_path(f) for f in ('as.1', 'bs.2', 'cs.3', 'ds.4')}
 
-def test_select2(tmp_target_dir, conf):
-    conf.read_dict({'source': {'eval': 'filter1', 'path': str(tmp_target_dir)},
+def test_select2(working_dir, conf):
+    src_dir, target_dir = working_dir
+    conf.read_dict({'source': {'eval': 'filter1', 'path': str(src_dir)},
                     'source.filter1': {'name': '.*2$'},
                     'target': {'name of the target files': '%ne', 'tags': ''}})
 
     katal.read_filters()
     katal.fill_select()
 
-    assert {e.srcname for e in katal.SELECT} == {tmp_target_dir.join(f) for f in ('b.2',)}
+    assert {e.srcname for e in katal.SELECT} == {src_dir.join(f) for f in ('b.2',)}
     assert {e.targetname for e in katal.SELECT} == {pwd_path(f) for f in ('b.2e',)}
 
-def test_select3(tmp_target_dir, conf):
-    conf.read_dict({'source': {'eval': 'filter1', 'path': str(tmp_target_dir)},
+def test_select3(working_dir, conf):
+    src_dir, target_dir = working_dir
+    conf.read_dict({'source': {'eval': 'filter1', 'path': str(src_dir)},
                     'source.filter1': {'size': '<=1kB'},
                     'target': {'name of the target files': '%n', 'tags': ''}})
 
     katal.read_filters()
     katal.fill_select()
 
-    assert {e.srcname for e in katal.SELECT} == {tmp_target_dir.join(f) for f in ('b.2', 'c.3', 'd.4')}
+    assert {e.srcname for e in katal.SELECT} == {src_dir.join(f) for f in ('b.2', 'c.3', 'd.4')}
     assert {e.targetname for e in katal.SELECT} == {pwd_path(f) for f in ('b.2', 'c.3', 'd.4')}
 
-def test_select3(tmp_target_dir, conf):
-    conf.read_dict({'source': {'eval': 'filter1', 'path': str(tmp_target_dir)},
+def test_select3(working_dir, conf):
+    src_dir, target_dir = working_dir
+    conf.read_dict({'source': {'eval': 'filter1', 'path': str(src_dir)},
                     'source.filter1': {'size': '<=1kB', 'date': '>=2016-01-24 13:00'},
                     'target': {'name of the target files': '%n', 'tags': ''}})
 
     katal.read_filters()
     katal.fill_select()
 
-    assert {e.srcname for e in katal.SELECT} == {tmp_target_dir.join(f) for f in ('c.3', 'd.4')}
+    assert {e.srcname for e in katal.SELECT} == {src_dir.join(f) for f in ('c.3', 'd.4')}
     assert {e.targetname for e in katal.SELECT} == {pwd_path(f) for f in ('c.3', 'd.4')}
 
-def test_select4(tmp_target_dir, conf):
-    conf.read_dict({'source': {'eval': 'filter1', 'path': str(tmp_target_dir)},
+def test_select4(working_dir, conf):
+    src_dir, target_dir = working_dir
+    conf.read_dict({'source': {'eval': 'filter1', 'path': str(src_dir)},
                     'source.filter1': {'size': '<=1kB', 'date': '>=2016-02'},
                     'target': {'name of the target files': '%n', 'tags': ''}})
 
     katal.read_filters()
     katal.fill_select()
 
-    assert {e.srcname for e in katal.SELECT} == {tmp_target_dir.join(f) for f in ('d.4',)}
+    assert {e.srcname for e in katal.SELECT} == {src_dir.join(f) for f in ('d.4',)}
     assert {e.targetname for e in katal.SELECT} == {pwd_path(f) for f in ('d.4',)}
 
-def test_select5(tmp_target_dir, conf):
-    conf.read_dict({'source': {'eval': 'filter1', 'path': str(tmp_target_dir)},
+def test_select5(working_dir, conf):
+    src_dir, target_dir = working_dir
+    conf.read_dict({'source': {'eval': 'filter1', 'path': str(src_dir)},
                     'source.filter1': {'date': '<=2016-02'},
                     'target': {'name of the target files': '%Y-%d(%m)-%f', 'tags': ''}})
 
     katal.read_filters()
     katal.fill_select()
 
-    assert {e.srcname for e in katal.SELECT} == {tmp_target_dir.join(f) for f in ('b.2', 'c.3')}
+    assert {e.srcname for e in katal.SELECT} == {src_dir.join(f) for f in ('b.2', 'c.3')}
     assert {e.targetname for e in katal.SELECT} == {pwd_path(f) for f in ('2016-01-b', '2016-01-c')}
 
-def test_select6(tmp_target_dir, conf):
-    conf.read_dict({'source': {'eval': 'filter1', 'path': str(tmp_target_dir)},
+def test_select6(working_dir, conf):
+    src_dir, target_dir = working_dir
+    conf.read_dict({'source': {'eval': 'filter1', 'path': str(src_dir)},
                     'source.filter1': {'external program': 'false'},
                     'target': {'name of the target files': '%n', 'tags': ''}})
 
@@ -169,14 +195,85 @@ def test_select6(tmp_target_dir, conf):
     assert {e.srcname for e in katal.SELECT} == set()
     assert {e.targetname for e in katal.SELECT} == set()
 
-def test_subdir1(tmp_target_dir, conf):
-    conf.read_dict({'source': {'eval': 'filter1', 'path': str(tmp_target_dir)},
+def test_subdir1(working_dir, conf):
+    src_dir, target_dir = working_dir
+    conf.read_dict({'source': {'eval': 'filter1', 'path': str(src_dir)},
                     'source.filter1': {},
                     'target': {'name of the target files': '%Y/%n', 'tags': ''}})
 
     katal.read_filters()
     katal.fill_select()
 
-    assert {e.srcname for e in katal.SELECT} == {tmp_target_dir.join(f) for f in ('a.1', 'b.2', 'c.3', 'd.4')}
+    assert {e.srcname for e in katal.SELECT} == {src_dir.join(f) for f in ('a.1', 'b.2', 'c.3', 'd.4')}
     assert {e.targetname for e in katal.SELECT} == {pwd_path(f) for f in ('2016/a.1', '2016/b.2', '2016/c.3', '2016/d.4')}
+
+def test_copy(working_dir, conf):
+    src_dir, target_dir = working_dir
+    conf.read_dict({'source': {'eval': 'filter1', 'path': str(src_dir)},
+                    'source.filter1': {},
+                    'target': {'name of the target files': '%n', 'tags': '', 'mode': 'copy'}})
+
+    conf.targetpath = str(target_dir)
+
+    katal.read_target_db()
+    katal.read_filters()
+    katal.fill_select()
+    katal.action__add()
+
+    assert target_dir.join(katal.CST__KATALSYS_SUBDIR, katal.CST__DATABASE_NAME).isfile()
+
+    list_target_files = []
+    for dirpath, _, filenames in os.walk(str(target_dir)):
+        list_target_files.extend(os.path.join(dirpath, f) for f in filenames
+                                 if '.katal' not in dirpath)
+
+    assert set(list_target_files) == {(target_dir.join(f)) for f in ('a.1', 'b.2', 'c.3', 'd.4')}
+
+    db = read_db(conf)
+    list_src_names = {row['sourcename'] for row in db}
+    list_target_names = {row['targetname'] for row in db}
+    list_hashid = {row['hashid'] for row in db}
+
+    assert list_src_names == {src_dir.join(f) for f in ('a.1', 'b.2', 'c.3', 'd.4')}
+    assert list_target_names == {target_dir.join(f) for f in ('a.1', 'b.2', 'c.3', 'd.4')}
+    assert list_hashid == {katal.hashfile64(f) for f in list_target_names}
+
+    # files are equals
+    assert all(filecmp.cmp(str(target_dir.join(f)), str(src_dir.join(f)))
+               for f in ('a.1', 'b.2', 'c.3', 'd.4'))
+
+def test_move(working_dir, conf):
+    src_dir, target_dir = working_dir
+    print(target_dir)
+    conf.read_dict({'source': {'eval': 'filter1', 'path': str(src_dir)},
+                    'source.filter1': {},
+                    'target': {'name of the target files': 's%n', 'tags': '', 'mode': 'move'}})
+
+    conf.targetpath = str(target_dir)
+
+    katal.read_target_db()
+    katal.read_filters()
+    katal.fill_select()
+    katal.action__add()
+
+    assert target_dir.join(katal.CST__KATALSYS_SUBDIR, katal.CST__DATABASE_NAME).isfile()
+
+    list_target_files = []
+    for dirpath, _, filenames in os.walk(str(target_dir)):
+        list_target_files.extend(os.path.join(dirpath, f) for f in filenames
+                                 if '.katal' not in dirpath)
+
+    assert set(list_target_files) == {(target_dir.join(f)) for f in ('sa.1', 'sb.2', 'sc.3', 'sd.4')}
+
+    # all files well moved
+    assert src_dir.listdir() == []
+
+    db = read_db(conf)
+    list_src_names = {row['sourcename'] for row in db}
+    list_target_names = {row['targetname'] for row in db}
+    list_hashid = {row['hashid'] for row in db}
+
+    assert list_src_names == {src_dir.join(f) for f in ('a.1', 'b.2', 'c.3', 'd.4')}
+    assert list_target_names == {target_dir.join(f) for f in ('sa.1', 'sb.2', 'sc.3', 'sd.4')}
+    assert list_hashid == {katal.hashfile64(f) for f in list_target_names}
 


### PR DESCRIPTION
J'ai continué à tout chambouler, et voilà un nouveau (gros) pull request.

J'ai principalement changé la façon dont les fichiers sont représentés. Chaque fichier manipulé est dorénavant représenté par une classe SelectElement, ce qui simplifie la logique du code, et ils ne sont plus stockés dans des dictionnaires avec leur hash comme clé, mais dans des sets, ce qui a comme effet de bord de résoudre #64 

En plus de cela, j'ai ajouté quelques modifications :
- Ajout de nouveaux moyens de nommer les fichiers cibles basés sur les dates
- Ajout de la gestion des sous-dossiers, à la fois dans la source et la cible (ce qui permet de copier src/sub/file dans target/2016/file par exemple)
- Par défaut, les fichiers cachés sont ignorés
- Suppression du filtre name_not_already_present qui était effectivement mal conçu (résout #67)
- Ajout de quelques tests unitaires sur les fonctions select, add et rebase, ce qui m'a permis de résoudre pas mal de  bugs que j'avais introduits auparavant. 
- Quand l'action add ou rebase échoue, tout est fait pour revenir à l'état antérieur, ce qui est évite d'avoir des fichiers à moitié copié ou une base de données pas à jour en cas d'erreur. Il faudrait s'assurer de faire de même pour tout opération.
